### PR TITLE
Add ineligible pages

### DIFF
--- a/app/controllers/coronavirus_form/not_eligible_medical_controller.rb
+++ b/app/controllers/coronavirus_form/not_eligible_medical_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::NotEligibleMedicalController < ApplicationController
+  def show
+    render "coronavirus_form/not_eligible_medical"
+  end
+end

--- a/app/controllers/coronavirus_form/not_eligible_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/not_eligible_supplies_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::NotEligibleSuppliesController < ApplicationController
+  def show
+    render "coronavirus_form/not_eligible_supplies"
+  end
+end

--- a/app/views/coronavirus_form/not_eligible_medical.html.erb
+++ b/app/views/coronavirus_form/not_eligible_medical.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %><%= t('not_eligible_medical.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('not_eligible_medical.title') %>" />
+<% end %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title: t('not_eligible_medical.title'),
+  margin_top: 0
+} %>
+<%= sanitize(t('not_eligible_medical.description')) %>

--- a/app/views/coronavirus_form/not_eligible_supplies.html.erb
+++ b/app/views/coronavirus_form/not_eligible_supplies.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %><%= t('not_eligible_supplies.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('not_eligible_supplies.title') %>" />
+<% end %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title: t('not_eligible_supplies.title'),
+  margin_top: 0
+} %>
+<%= sanitize(t('not_eligible_supplies.description')) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,20 @@ en:
     button_label: Start now
   check_your_answers:
     title: "Work in progress"
+  not_eligible_medical:
+    title: Sorry, you’re not eligible for help through this service at the moment
+    description: |
+      <p class="govuk-body">Your local authority needs to prioritise people who have a medical condition that makes them extremely vulnerable to coronavirus, so you will not be eligible for direct support from your local authority.</p>
+      <p class="govuk-body">You can get help on <a class="govuk-link" href="https://www.gov.uk/coronavirus">what you need to do</a>.</p>
+      <p class="govuk-body">If your medical condition changes, return to <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">the start of this service</a> and go through the questions again.</p>
+      <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
+  not_eligible_supplies:
+    title: Sorry, you’re not eligible for help through this service at the moment
+    description: |
+      <p class="govuk-body">Your local authority needs to prioritise people who do not have anyone to help with essential supplies, so you will not be eligible for direct support from your local authority.</p>
+      <p class="govuk-body">You can get help on <a class="govuk-link" href="https://www.gov.uk/coronavirus">what you need to do</a>.</p>
+      <p class="govuk-body">If your situation changes, return to <a class="govuk-link" ref="https://www.gov.uk/coronavirus-extremely-vulnerable">the start of this service</a> and go through the questions again.</p>
+      <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
   coronavirus_form:
     errors:
       heading: "There is a problem"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,12 @@ Rails.application.routes.draw do
   get "/coronavirus-form/check-your-answers" => "coronavirus_form/check_answers#show"
   post "/coronavirus-form/check-your-answers" => "coronavirus_form/check_answers#submit"
 
+  # Not eligible for supplies
+  get "/coronavirus-form/not-eligible-medical" => "coronavirus_form/not_eligible_medical#show"
+
+  # Check answers page
+  get "/coronavirus-form/not-eligible-supplies" => "coronavirus_form/not_eligible_supplies#show"
+
   # Final page
   get "/coronavirus-form/confirmation" => "coronavirus_form/confirmation#show"
 end

--- a/spec/controllers/coronavirus_form/not_eligible_medical_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/not_eligible_medical_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::NotEligibleMedicalController, type: :controller do
+  let(:current_template) { "coronavirus_form/not_eligible_medical" }
+
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/not_eligible_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/not_eligible_supplies_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::NotEligibleSuppliesController, type: :controller do
+  let(:current_template) { "coronavirus_form/not_eligible_supplies" }
+
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+end


### PR DESCRIPTION
We route people to one of these two pages if they are not eligible for the service.

https://trello.com/c/XPHkrCje/52-ineligible-screen-2
Supplies:

<img width="717" alt="Screenshot 2020-03-21 at 16 59 01" src="https://user-images.githubusercontent.com/8124374/77231883-94dc8300-6b95-11ea-9266-6a41c9fb5dfc.png">

https://trello.com/c/ojiB4TUg/51-ineligible-screen-1
Medical: 

<img width="856" alt="Screenshot 2020-03-21 at 16 58 29" src="https://user-images.githubusercontent.com/8124374/77231881-91e19280-6b95-11ea-99db-be1813e2a6d9.png">
