### PR TITLE
rubocop: Exclude config/routes.rb from Metrics/BlockLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
+
+Metrics/BlockLength:
+  Exclude:
+    - config/routes.rb


### PR DESCRIPTION
- When I rebased one of the question PRs, RuboCop moaned about this.
- There are going to be many more routes and we can't help that...