### PR TITLE
Check for session data for viewing the check your answers page.

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -4,8 +4,12 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
 
   def show
-    session[:check_answers_seen] = true
-    render "coronavirus_form/check_answers"
+    if session[:nhs_letter].present?
+      session[:check_answers_seen] = true
+      render "coronavirus_form/check_answers"
+    else
+      redirect_to controller: "coronavirus_form/start", action: "show"
+    end
   end
 
   def submit

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -7,8 +7,15 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session["nhs_letter"] = "yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to({ controller: "start", action: "show" })
     end
   end
 


### PR DESCRIPTION
This is very blunt and simple check to see if the user has at least
visited the first question before allowing them to view the check
your answers page. This should help prevent incorrect sumbission for
people who've not completed the full question flow.