### PR TITLE
Update content on confirmation page

### DIFF
--- a/app/views/coronavirus_form/confirmation.html.erb
+++ b/app/views/coronavirus_form/confirmation.html.erb
@@ -2,3 +2,5 @@
 <%= render "govuk_publishing_components/components/panel", {
   title: t("coronavirus_form.confirmation.title")
 } %>
+
+<%= sanitize(t('coronavirus_form.confirmation.description')) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,7 +109,12 @@ en:
       email:
         label: "Email address"
     confirmation:
-      title: "Confirmation"
+      title: "Registration complete."
+      description: |
+        <p class="govuk-body">If your support needs change, go to <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">www.gov.uk/coronavirus-extremely-vulnerable</a> and go through the questions again.</p>
+        <p class="govuk-body">If you need essential supplies urgently, call <a class="govuk-link" href="tel:0800 0288327">0800 0288327</a>.</p>
+        <p class="govuk-body">If you need medical advice, call the NHS on 111. If it's a medical emergecy, call 999.</p>
+        <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
     name:
       title: What is your name?
       first_name:


### PR DESCRIPTION
Path: `/coronavirus-form/confirmation`

https://trello.com/c/cnOBbnCz/50-update-the-confirmation-page-view

<img width="777" alt="Screenshot 2020-03-21 at 17 21 17" src="https://user-images.githubusercontent.com/8124374/77232399-b8ed9380-6b98-11ea-9aad-6a124354b4df.png">
