### PR TITLE
Add exclude for rubocop block length rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
+
+Metrics/BlockLength:
+  Exclude:
+    - config/routes.rb


### PR DESCRIPTION
#Why

Our routes get loooooonnng for this app. and the linting doesn't provide any value here. We can use code-review to keep each other honest about complexity