### PR TITLE
Make validation errors appear on all pages when needed

### DIFF
--- a/app/views/coronavirus_form/addiction.html.erb
+++ b/app/views/coronavirus_form/addiction.html.erb
@@ -16,6 +16,7 @@
   heading: t('coronavirus_form.addiction.title'),
   is_page_heading: true,
   name: "addiction",
+  error_message: error_items('addiction'),
   items: t('coronavirus_form.addiction.options').map do |_, item|
     {
       value: item[:label],

--- a/app/views/coronavirus_form/know_nhs_number.html.erb
+++ b/app/views/coronavirus_form/know_nhs_number.html.erb
@@ -16,6 +16,7 @@
       heading: t('coronavirus_form.know_nhs_number.title'),
       is_page_heading: true,
       name: "know_nhs_number",
+      error_message: error_items('know_nhs_number'),
       hint: sanitize(t('coronavirus_form.know_nhs_number.hint')),
       items: t('coronavirus_form.know_nhs_number.options').map do |_, item|
         {

--- a/app/views/coronavirus_form/medical_conditions.html.erb
+++ b/app/views/coronavirus_form/medical_conditions.html.erb
@@ -16,6 +16,7 @@
       heading: t('coronavirus_form.medical_conditions.title'),
       is_page_heading: true,
       name: "medical_conditions",
+      error_message: error_items('medical_conditions'),
       description: sanitize(t('coronavirus_form.medical_conditions.description')),
       items: t('coronavirus_form.medical_conditions.options').map do |_, item|
         {

--- a/app/views/coronavirus_form/nhs_letter.html.erb
+++ b/app/views/coronavirus_form/nhs_letter.html.erb
@@ -16,6 +16,7 @@
   heading: t('coronavirus_form.nhs_letter.title'),
   is_page_heading: true,
   name: "nhs_letter",
+  error_message: error_items('nhs_letter'),
   items: t('coronavirus_form.nhs_letter.options').map do |_, item|
     {
       value: item[:label],

--- a/app/views/coronavirus_form/temperature_or_cough.html.erb
+++ b/app/views/coronavirus_form/temperature_or_cough.html.erb
@@ -16,6 +16,7 @@
   heading: t('coronavirus_form.temperature_or_cough.title'),
   is_page_heading: true,
   name: "temperature_or_cough",
+  error_message: error_items('temperature_or_cough'),
   hint: t('coronavirus_form.temperature_or_cough.hint'),
   items: t('coronavirus_form.temperature_or_cough.options').map do |_, item|
     {

--- a/app/views/coronavirus_form/virus_test.html.erb
+++ b/app/views/coronavirus_form/virus_test.html.erb
@@ -16,6 +16,7 @@
   heading: t('coronavirus_form.virus_test.title'),
   is_page_heading: true,
   name: "virus_test",
+  error_message: error_items('virus_test'),
   items: t('coronavirus_form.virus_test.options').map do |_, item|
     {
       value: item[:label],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
           label: "No"
         not_sure:
           label: "Not sure"
+      custom_select_error: Please select Yes or No
     medical_conditions:
       title: Do you have a medical condition that makes you vulnerable to coronavirus?
       description: |
@@ -63,6 +64,7 @@ en:
           label: "Yes, I have a medical condition that makes me vulnerable to coronavirus"
         option_no:
           label: "No, I do not have a medical condition that makes me vulnerable to coronavirus"
+      custom_select_error: Please select Yes or No
     temperature_or_cough:
       title: Do you have a high temperature or a new, continuous cough?
       hint: A continuous cough means coughing a lot for more than an hour, or 3 or more coughing episodes in 24 hours
@@ -71,6 +73,7 @@ en:
           label: "Yes"
         option_no:
           label: "No"
+      custom_select_error: Please select Yes or No
     virus_test:
       title: Have you been tested for coronavirus?
       options:
@@ -80,6 +83,7 @@ en:
           label: Yes, I've been tested and I do not have coronavirus
         option_no:
           label: No, I have not been tested
+      custom_select_error: Please select an option
     carry_supplies:
       title: Is there someone in the house who's able to carry a delivery of supplies inside?
       options:
@@ -133,6 +137,7 @@ en:
           label: "Yes, I know my NHS number"
         option_no:
           label: "No, I do not know my NHS number"
+      custom_select_error: Please select Yes or No
     confirmation:
       title: "Registration complete."
       description: |


### PR DESCRIPTION
- We missed including `error_message` in the component, so it didn't
  know which error message to render.
- This also sets snappier error messages than re-printing the question
  titles, for those that didn't already have them.

A selection of screenshots is below...

<img width="1920" alt="Screenshot 2020-03-21 at 19 54 30" src="https://user-images.githubusercontent.com/355033/77235529-4daebc00-6bae-11ea-9352-41db41f758d8.png">

<img width="1920" alt="Screenshot 2020-03-21 at 19 54 59" src="https://user-images.githubusercontent.com/355033/77235530-4e475280-6bae-11ea-89d1-491cd727cbd6.png">

<img width="1920" alt="Screenshot 2020-03-21 at 19 54 22" src="https://user-images.githubusercontent.com/355033/77235528-4c7d8f00-6bae-11ea-9503-7cc6afe1381e.png">
