### PR TITLE
Add validation error logging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,8 @@ private
   def previous_path
     raise NotImplementedError, "Define a previous path"
   end
+
+  def log_validation_error(invalid_fields)
+    logger.info "validation error - #{invalid_fields.pluck(:text).to_sentence}"
+  end
 end

--- a/app/controllers/coronavirus_form/addiction_controller.rb
+++ b/app/controllers/coronavirus_form/addiction_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::AddictionController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/addiction_controller.rb
+++ b/app/controllers/coronavirus_form/addiction_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::AddictionController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -19,7 +19,8 @@ class CoronavirusForm::BasicCareNeedsController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      log_validation_error(invalid_fields)
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/carry_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/carry_supplies_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::CarrySuppliesController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/carry_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/carry_supplies_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::CarrySuppliesController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -20,7 +20,7 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -20,6 +20,7 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -24,6 +24,7 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -24,7 +24,7 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::DietaryRequirementsController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::DietaryRequirementsController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::EssentialSuppliesController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::EssentialSuppliesController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     elsif session[:know_nhs_number] == I18n.t("coronavirus_form.know_nhs_number.options.option_no.label")

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::MedicalConditionsController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::MedicalConditionsController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::NameController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::NameController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::NhsLetterController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::NhsLetterController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -26,7 +26,7 @@ class CoronavirusForm::SupportAddressController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -26,6 +26,7 @@ class CoronavirusForm::SupportAddressController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/temperature_or_cough_controller.rb
+++ b/app/controllers/coronavirus_form/temperature_or_cough_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::TemperatureOrCoughController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/temperature_or_cough_controller.rb
+++ b/app/controllers/coronavirus_form/temperature_or_cough_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::TemperatureOrCoughController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/virus_test_controller.rb
+++ b/app/controllers/coronavirus_form/virus_test_controller.rb
@@ -19,6 +19,7 @@ class CoronavirusForm::VirusTestController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
+      log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"

--- a/app/controllers/coronavirus_form/virus_test_controller.rb
+++ b/app/controllers/coronavirus_form/virus_test_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::VirusTestController < ApplicationController
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
-      render "coronavirus_form/#{PAGE}"
+      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/spec/controllers/coronavirus_form/addiction_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/addiction_controller_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe CoronavirusForm::AddictionController, type: :controller do
 
     it "validates any option is chosen" do
       post :submit, params: { addiction: "" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
     it "validates a valid option is chosen" do
       post :submit, params: { addiction: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe CoronavirusForm::BasicCareNeedsController, type: :controller do
 
     it "validates any option is chosen" do
       post :submit, params: { basic_care_needs: "" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
     it "validates a valid option is chosen" do
       post :submit, params: { basic_care_needs: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
     it "validates any option is chosen" do
       post :submit, params: { carry_supplies: "" }
 
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
@@ -38,6 +39,7 @@ RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
     it "validates a valid option is chosen" do
       post :submit, params: { carry_supplies: "<script></script>" }
 
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
 
     it "does not move to next step with an invalid email address" do
       post :submit, params: { email: "not-a-valid-email" }
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
 
     it "does not move to next step if a field is missing" do
       post :submit, params: { "date_of_birth" => { "day" => "31" } }
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
@@ -51,6 +52,7 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
           "year" => "not a number",
         },
       }
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller
 
     it "validates any option is chosen" do
       post :submit, params: { dietary_requirements: "" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
@@ -37,7 +37,7 @@ RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller
 
     it "validates a valid option is chosen" do
       post :submit, params: { dietary_requirements: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
 
     it "validates any option is chosen" do
       post :submit, params: { essential_supplies: "" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
@@ -37,7 +37,7 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
 
     it "validates a valid option is chosen" do
       post :submit, params: { essential_supplies: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
 
     it "validates any option is chosen" do
       post :submit, params: { know_nhs_number: "" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
     it "validates a valid option is chosen" do
       post :submit, params: { know_nhs_number: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
 
     it "validates any option is chosen" do
       post :submit, params: { medical_conditions: "" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
@@ -37,7 +37,7 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
 
     it "validates a valid option is chosen" do
       post :submit, params: { medical_conditions: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
     %w(first_name last_name).each do |field|
       it "validates #{field} is required" do
         post :submit, params: params.except(field)
-
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(current_template)
       end
 
       it "validates a value for #{field} is required" do
         post :submit, params: params.merge(field => "")
-
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(current_template)
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
 
     it "validates a valid option is chosen" do
       post :submit, params: { first_name: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
 
     it "validates any option is chosen" do
       post :submit, params: { nhs_letter: "" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
     it "validates a valid option is chosen" do
       post :submit, params: { nhs_letter: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
     described_class::REQUIRED_FIELDS.each do |field|
       it "requires that key #{field} be provided" do
         post :submit, params: params.except(field)
-
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(current_template)
       end
     end

--- a/spec/controllers/coronavirus_form/temperature_or_cough_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/temperature_or_cough_controller_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe CoronavirusForm::TemperatureOrCoughController, type: :controller 
 
     it "validates any option is chosen" do
       post :submit, params: { temperature_or_cough: "" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
     it "validates a valid option is chosen" do
       post :submit, params: { temperature_or_cough: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 

--- a/spec/controllers/coronavirus_form/virus_test_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/virus_test_controller_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe CoronavirusForm::VirusTestController, type: :controller do
 
     it "validates any option is chosen" do
       post :submit, params: { virus_test: "" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 
     it "validates a valid option is chosen" do
       post :submit, params: { virus_test: "<script></script>" }
-
+      expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end
 


### PR DESCRIPTION
This will return a 422 status for validation errors and log validation error messages.

Example:

```
validation error - Date of birth must include a year and Date of birth must include a month
```

https://trello.com/c/8eJehWes/65-add-logging-for-validation-errors
https://trello.com/c/XzYo085V/70-return-a-422-status-code-for-validation-errors