### PR TITLE
Show list of questions and answers on check-your-answers page

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -5,6 +5,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
   def show
     if session[:nhs_letter].present?
+      @items = items
       session[:check_answers_seen] = true
       render "coronavirus_form/check_answers"
     else
@@ -29,5 +30,30 @@ private
     timestamp = Time.zone.now.strftime("%Y%m%d-%H%M%S")
     random_id = SecureRandom.hex(3).upcase
     "#{timestamp}-#{random_id}"
+  end
+
+  def items
+    questions.map do |question|
+      # We have answers as strings and hashes. The hashes need a little more
+      # work to make them readable.
+      value = session[question].is_a?(Hash) ? concat_answer(session[question]) : session[question]
+
+      {
+        field: t("coronavirus_form.questions.#{question}.title"),
+        value: value,
+        edit: {
+          href: question.dasherize,
+        },
+      }
+    end
+  end
+
+  def concat_answer(answer)
+    answer.values.compact.join(" ")
+  end
+
+  def questions
+    @questions ||= YAML.load_file(Rails.root.join("config/locales/en.yml"))
+    @questions["en"]["coronavirus_form"]["questions"].keys
   end
 end

--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -1,9 +1,27 @@
-<% content_for :title do %><%= t('check_your_answers.title') %><% end %>
+<% content_for :title do %>
+  <%= t('check_your_answers.title') %>
+<% end %>
+
 <% content_for :meta_tags do %>
   <meta name="description" content="<%= t('check_your_answers.title') %>" />
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
   title: t('check_your_answers.title'),
-  margin_top: 0
+  margin_top: 0,
 } %>
+
+<%= render "govuk_publishing_components/components/summary_list", {
+  items: @items,
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t('check_your_answers.heading'),
+  heading_level: 4
+} %>
+
+<p class="govuk-body">
+  <%= t('check_your_answers.confirmation') %>
+</p>
+
+<%= render "govuk_publishing_components/components/button", text: "Accept and send", margin_bottom: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,9 @@ en:
     body: Work in progress
     button_label: Start now
   check_your_answers:
-    title: "Work in progress"
+    title: Check your answers before sending your application
+    heading: Now send your application
+    confirmation: By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.
   not_eligible_medical:
     title: Sorry, you’re not eligible for help through this service at the moment
     description: |


### PR DESCRIPTION
Trello: https://trello.com/c/9AXp3Vy6/47-check-your-answers-page

Show the list of questions and answers on the check_answers page.
The list should show the questions in the same order that they appear in
the YAML file.

At the moment there is no guard that checks whether the question was
answered or skipped, but we can add that in later.

![screenshot-localhost-5000-2020 03 22-12-32-38](https://user-images.githubusercontent.com/5793815/77249538-9c556800-6c39-11ea-834a-7f2d9f1aaa6b.png)

The prototype has a line break between the "Now send your application" heading and the text below it: https://c19-prototypes.cloudapps.digital/vulnerable-people/v4/check-your-answers but I haven't figured out the best way to do this. Suggestions please!

Authored with: @injms 