### PR TITLE
Add error summary component for errors

### DIFF
--- a/app/views/application/_error_summary.html.erb
+++ b/app/views/application/_error_summary.html.erb
@@ -1,0 +1,11 @@
+<% if flash[:validation]&.any? %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: "There is a problem",
+    items: flash[:validation].map { |error| 
+      {
+        text: error[:text],
+        href: "#" + error[:field]
+      } 
+    }
+  } %>
+<% end %>

--- a/app/views/coronavirus_form/_validation_error.html.erb
+++ b/app/views/coronavirus_form/_validation_error.html.erb
@@ -1,5 +1,0 @@
-<% if flash[:validation]&.any? %>
-  <%= render "govuk_publishing_components/components/error_message", {
-    items: flash[:validation].map { |field| { text: field[:text] } }
-  } %>
-<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,7 @@
       <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
+            <%= render "error_summary" %>
             <%= yield %>
           </div>
         </div>


### PR DESCRIPTION
Will need to test this more when we get more of the validation in, but for now this enables the error summary at the top of question pages to link to the field that has errored.

https://design-system.service.gov.uk/components/error-summary/