### PR TITLE
Update i18n shape to nest questions in own key

### DIFF
--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -23,7 +23,7 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
-    elsif session[:know_nhs_number] == I18n.t("coronavirus_form.know_nhs_number.options.option_no.label")
+    elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
       redirect_to controller: "coronavirus_form/essential_supplies", action: "show"
     else
       redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -38,8 +38,8 @@ private
       next if session["name"][field].present?
 
       invalid_fields << { field: field.to_s,
-                          text: t("coronavirus_form.#{page}.#{field}.custom_error",
-                                  default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.#{page}.#{field}.label")).humanize) }
+                          text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",
+                                  default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.questions.#{page}.#{field}.label")).humanize) }
     end
   end
 

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -75,9 +75,9 @@ private
 
       invalid_fields << {
         field: field.to_s,
-        text: t("coronavirus_form.#{PAGE}.#{field}.custom_error",
+        text: t("coronavirus_form.questions.#{PAGE}.#{field}.custom_error",
                 default: t("coronavirus_form.errors.missing_mandatory_text_field",
-                           field: t("coronavirus_form.#{PAGE}.#{field}.label")).humanize),
+                           field: t("coronavirus_form.questions.#{PAGE}.#{field}.label")).humanize),
       }
     end
   end

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -7,7 +7,7 @@ module FieldValidationHelper
       next if session[field].present?
 
       invalid_fields << { field: field.to_s,
-                          text: t("coronavirus_form.#{page}.#{field}.custom_error",
+                          text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",
                                   default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.#{page}.#{field}.label")).humanize) }
     end
     invalid_fields
@@ -17,16 +17,16 @@ module FieldValidationHelper
     if radio.blank?
       return [{ field: page.to_s,
                 text: t(
-                  "coronavirus_form.#{page}.custom_select_error",
-                  default: t("coronavirus_form.errors.radio_field", field: t("coronavirus_form.#{page}.title")).humanize,
+                  "coronavirus_form.questions.#{page}.custom_select_error",
+                  default: t("coronavirus_form.errors.radio_field", field: t("coronavirus_form.questions.#{page}.title")).humanize,
                 ) }]
     end
 
     if other != false && other.blank? && %w[Yes Other].include?(radio)
       return [{ field: page.to_s,
                 text: t(
-                  "coronavirus_form.#{page}.custom_enter_error",
-                  default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.#{page}.title")).humanize,
+                  "coronavirus_form.questions.#{page}.custom_enter_error",
+                  default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.questions.#{page}.title")).humanize,
                 ) }]
     end
 
@@ -37,16 +37,16 @@ module FieldValidationHelper
     if values.blank? || values.empty?
       return [{ field: page.to_s,
                 text: t(
-                  "coronavirus_form.#{page}.custom_select_error",
-                  default: t("coronavirus_form.errors.checkbox_field", field: t("coronavirus_form.#{page}.title")).humanize,
+                  "coronavirus_form.questions.#{page}.custom_select_error",
+                  default: t("coronavirus_form.errors.checkbox_field", field: t("coronavirus_form.questions.#{page}.title")).humanize,
                 ) }]
     end
 
     if (values - allowed_values).any?
       return [{ field: page.to_s,
                 text: t(
-                  "coronavirus_form.#{page}.custom_select_error",
-                  default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.#{page}.title")).humanize,
+                  "coronavirus_form.questions.#{page}.custom_select_error",
+                  default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.questions.#{page}.title")).humanize,
                 ) }]
     end
 

--- a/app/views/coronavirus_form/addiction.html.erb
+++ b/app/views/coronavirus_form/addiction.html.erb
@@ -1,6 +1,8 @@
-<% content_for :title do %><%= t('coronavirus_form.addiction.title') %><% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.addiction.title") %>
+<% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.addiction.title') %>" />
+  <meta name="description" content="<%= t('coronavirus_form.questions.addiction.title') %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -13,11 +15,11 @@
   "id": "addiction"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.addiction.title'),
+  heading: t("coronavirus_form.questions.addiction.title"),
   is_page_heading: true,
   name: "addiction",
-  error_message: error_items('addiction'),
-  items: t('coronavirus_form.addiction.options').map do |_, item|
+  error_message: error_items("addiction"),
+  items: t("coronavirus_form.questions.addiction.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],

--- a/app/views/coronavirus_form/basic_care_needs.erb
+++ b/app/views/coronavirus_form/basic_care_needs.erb
@@ -1,6 +1,8 @@
-<% content_for :title do %><%= t('coronavirus_form.basic_care_needs.title') %><% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.basic_care_needs.title") %>
+<% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.basic_care_needs.title') %>" />
+  <meta name="description" content="<%= t('coronavirus_form.questions.basic_care_needs.title') %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -13,12 +15,12 @@
   "id": "basic_care_needs"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.basic_care_needs.title'),
-  hint: t('coronavirus_form.basic_care_needs.hint'),
+  heading: t("coronavirus_form.questions.basic_care_needs.title"),
+  hint: t("coronavirus_form.questions.basic_care_needs.hint"),
   is_page_heading: true,
   name: "basic_care_needs",
-  error_message: error_items('basic_care_needs'),
-  items: t('coronavirus_form.basic_care_needs.options').map do |_, item|
+  error_message: error_items("basic_care_needs"),
+  items: t("coronavirus_form.questions.basic_care_needs.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],

--- a/app/views/coronavirus_form/carry_supplies.html.erb
+++ b/app/views/coronavirus_form/carry_supplies.html.erb
@@ -1,7 +1,10 @@
-<% content_for :title do %><%= t('coronavirus_form.carry_supplies.title') %><% end %>
-    <% content_for :meta_tags do %>
-      <meta name="description" content="<%= t('coronavirus_form.carry_supplies.title') %>" />
-    <% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.carry_supplies.title") %>
+<% end %>
+
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('coronavirus_form.questions.carry_supplies.title') %>" />
+<% end %>
 
     <% content_for :back_link do %>
       <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
@@ -13,11 +16,11 @@
       "id": "carry_supplies"
     ) do %>
     <%= render "govuk_publishing_components/components/radio", {
-      heading: t('coronavirus_form.carry_supplies.title'),
+      heading: t("coronavirus_form.questions.carry_supplies.title"),
       is_page_heading: true,
       name: "carry_supplies",
-      error_message: error_items('carry_supplies'),
-      items: t('coronavirus_form.carry_supplies.options').map do |_, item|
+      error_message: error_items("carry_supplies"),
+      items: t("coronavirus_form.questions.carry_supplies.options").map do |_, item|
         {
           value: item[:label],
           text: item[:label],

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -1,6 +1,9 @@
-<% content_for :title do %><%= t('coronavirus_form.contact_details.title') %><% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.contact_details.title") %>
+<% end %>
+
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.contact_details.title') %>" />
+  <meta name="description" content="<%= t('coronavirus_form.questions.contact_details.title') %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -10,22 +13,22 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulnerable-people-contact_details",
   "data-question-key": "contact_details",
-  "id": "contact_details"
+  "id": "contact_details",
 ) do %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: t('coronavirus_form.contact_details.title'),
+  title: t("coronavirus_form.questions.contact_details.title"),
   margin_top: 0,
 } %>
 
 <%= render "govuk_publishing_components/components/hint", {
-  text: t('coronavirus_form.contact_details.hint'),
+  text: t("coronavirus_form.questions.contact_details.hint"),
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
   name: "phone_number_calls",
   label: {
-    text: t('coronavirus_form.contact_details.phone_number_calls.label'),
+    text: t("coronavirus_form.questions.contact_details.phone_number_calls.label"),
   },
   value: session.dig("contact_details", "phone_number_calls"),
   width: 20,
@@ -34,7 +37,7 @@
 <%= render "govuk_publishing_components/components/input", {
   name: "phone_number_texts",
   label: {
-    text: t('coronavirus_form.contact_details.phone_number_texts.label'),
+    text: t("coronavirus_form.questions.contact_details.phone_number_texts.label"),
   },
   value: session.dig("contact_details", "phone_number_texts"),
   width: 20,
@@ -43,7 +46,7 @@
 <%= render "govuk_publishing_components/components/input", {
   name: "email",
   label: {
-    text: t('coronavirus_form.contact_details.email.label'),
+    text: t("coronavirus_form.questions.contact_details.email.label"),
   },
   value: session.dig("contact_details", "email"),
 } %>

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -1,6 +1,8 @@
-<% content_for :title do %><%= t('coronavirus_form.date_of_birth.title') %><% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.date_of_birth.title") %>
+<% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.date_of_birth.title') %>" />
+  <meta name="description" content="<%= t('coronavirus_form.questions.date_of_birth.title') %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -13,13 +15,13 @@
   "id": "date_of_birth"
 ) do %>
 <%= render "govuk_publishing_components/components/title", {
-  title: t('coronavirus_form.date_of_birth.title'),
+  title: t("coronavirus_form.questions.date_of_birth.title"),
   margin_top: 0,
 } %>
 
 <%= render "govuk_publishing_components/components/date_input", {
   name: "date_of_birth",
-  legend_text: t('coronavirus_form.date_of_birth.hint'),
+  legend_text: t("coronavirus_form.questions.date_of_birth.hint"),
   error_message: error_items('date_of_birth'),
   items: [
     {

--- a/app/views/coronavirus_form/dietary_requirements.html.erb
+++ b/app/views/coronavirus_form/dietary_requirements.html.erb
@@ -1,11 +1,14 @@
-<% content_for :title do %><%= t('coronavirus_form.dietary_requirements.title') %><% end %>
-    <% content_for :meta_tags do %>
-      <meta name="description" content="<%= t('coronavirus_form.dietary_requirements.title') %>" />
-    <% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.dietary_requirements.title") %>
+<% end %>
 
-    <% content_for :back_link do %>
-      <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
-    <% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('coronavirus_form.questions.dietary_requirements.title') %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
 
     <%= form_tag({},
       "data-module": "track-coronavirus-form-vulnerable-people-dietary-requirements",
@@ -13,12 +16,12 @@
       "id": "dietary_requirements"
     ) do %>
     <%= render "govuk_publishing_components/components/radio", {
-      heading: t('coronavirus_form.dietary_requirements.title'),
+      heading: t("coronavirus_form.questions.dietary_requirements.title"),
       is_page_heading: true,
       name: "dietary_requirements",
-      description: sanitize(t('coronavirus_form.dietary_requirements.hint')),
-      error_message: error_items('dietary_requirements'),
-      items: t('coronavirus_form.dietary_requirements.options').map do |_, item|
+      description: sanitize(t("coronavirus_form.questions.dietary_requirements.hint")),
+      error_message: error_items("dietary_requirements"),
+      items: t("coronavirus_form.questions.dietary_requirements.options").map do |_, item|
         {
           value: item[:label],
           text: item[:label],

--- a/app/views/coronavirus_form/essential_supplies.html.erb
+++ b/app/views/coronavirus_form/essential_supplies.html.erb
@@ -1,7 +1,10 @@
-<% content_for :title do %><%= t('coronavirus_form.essential_supplies.title') %><% end %>
-    <% content_for :meta_tags do %>
-      <meta name="description" content="<%= t('coronavirus_form.essential_supplies.title') %>" />
-    <% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.essential_supplies.title") %>
+<% end %>
+
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t("coronavirus_form.questions.essential_supplies.title") %>" />
+<% end %>
 
     <% content_for :back_link do %>
       <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
@@ -13,12 +16,12 @@
       "id": "essential_supplies"
     ) do %>
     <%= render "govuk_publishing_components/components/radio", {
-      heading: t('coronavirus_form.essential_supplies.title'),
+      heading: t("coronavirus_form.questions.essential_supplies.title"),
       is_page_heading: true,
       name: "essential_supplies",
-      description: t('coronavirus_form.essential_supplies.hint'),
-      error_message: error_items('essential_supplies'),
-      items: t('coronavirus_form.essential_supplies.options').map do |_, item|
+      description: t("coronavirus_form.questions.essential_supplies.hint"),
+      error_message: error_items("essential_supplies"),
+      items: t("coronavirus_form.questions.essential_supplies.options").map do |_, item|
         {
           value: item[:label],
           text: item[:label],

--- a/app/views/coronavirus_form/know_nhs_number.html.erb
+++ b/app/views/coronavirus_form/know_nhs_number.html.erb
@@ -1,24 +1,28 @@
-<% content_for :title do %><%= t('coronavirus_form.know_nhs_number.title') %><% end %>
-    <% content_for :meta_tags do %>
-      <meta name="description" content="<%= t('coronavirus_form.know_nhs_number.title') %>" />
-    <% end %>
-    
-    <% content_for :back_link do %>
-      <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
-    <% end %>
-    
-    <%= form_tag({},
-      "data-module": "track-coronavirus-form-vulnerable-people-know_nhs_number",
-      "data-question-key": "know_nhs_number",
-      "id": "know_nhs_number"
-    ) do %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.know_nhs_number.title") %>
+<% end %>
+
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t("coronavirus_form.questions.know_nhs_number.title") %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
+
+<%= form_tag({},
+  "data-module": "track-coronavirus-form-vulnerable-people-know_nhs_number",
+  "data-question-key": "know_nhs_number",
+  "id": "know_nhs_number"
+) do %>
+
     <%= render "govuk_publishing_components/components/radio", {
-      heading: t('coronavirus_form.know_nhs_number.title'),
+      heading: t("coronavirus_form.questions.know_nhs_number.title"),
       is_page_heading: true,
       name: "know_nhs_number",
-      error_message: error_items('know_nhs_number'),
-      hint: sanitize(t('coronavirus_form.know_nhs_number.hint')),
-      items: t('coronavirus_form.know_nhs_number.options').map do |_, item|
+      error_message: error_items("know_nhs_number"),
+      hint: sanitize(t("coronavirus_form.questions.know_nhs_number.hint")),
+      items: t("coronavirus_form.questions.know_nhs_number.options").map do |_, item|
         {
           value: item[:label],
           text: item[:label],

--- a/app/views/coronavirus_form/medical_conditions.html.erb
+++ b/app/views/coronavirus_form/medical_conditions.html.erb
@@ -1,24 +1,27 @@
-<% content_for :title do %><%= t('coronavirus_form.medical_conditions.title') %><% end %>
-    <% content_for :meta_tags do %>
-      <meta name="description" content="<%= t('coronavirus_form.medical_conditions.title') %>" />
-    <% end %>
-    
-    <% content_for :back_link do %>
-      <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
-    <% end %>
-    
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.medical_conditions.title") %>
+<% end %>
+
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t("coronavirus_form.questions.medical_conditions.title") %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
+
     <%= form_tag({},
       "data-module": "track-coronavirus-form-vulnerable-people-medical_conditions",
       "data-question-key": "medical_conditions",
       "id": "medical_conditions"
     ) do %>
     <%= render "govuk_publishing_components/components/radio", {
-      heading: t('coronavirus_form.medical_conditions.title'),
+      heading: t("coronavirus_form.questions.medical_conditions.title"),
       is_page_heading: true,
       name: "medical_conditions",
-      error_message: error_items('medical_conditions'),
-      description: sanitize(t('coronavirus_form.medical_conditions.description')),
-      items: t('coronavirus_form.medical_conditions.options').map do |_, item|
+      error_message: error_items("medical_conditions"),
+      description: sanitize(t("coronavirus_form.questions.medical_conditions.description")),
+      items: t("coronavirus_form.questions.medical_conditions.options").map do |_, item|
         {
           value: item[:label],
           text: item[:label],
@@ -28,4 +31,4 @@
     } %>
     <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
     <% end %>
-    
+

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -1,6 +1,9 @@
-<% content_for :title do %><%= t('coronavirus_form.name.title') %><% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.name.title") %>
+<% end %>
+
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.name.title') %>" />
+  <meta name="description" content="<%= t('coronavirus_form.questions.name.title') %>">
 <% end %>
 
 <% content_for :back_link do %>
@@ -8,7 +11,7 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: t('coronavirus_form.name.title'),
+  title: t("coronavirus_form.questions.name.title"),
   margin_top: 0
 } %>
 
@@ -19,26 +22,28 @@
 ) do %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.name.first_name.label')
+    text: t("coronavirus_form.questions.name.first_name.label")
   },
   name: "first_name",
-  error_message: error_items('first_name'),
+  error_message: error_items("first_name"),
   value: session["name"]["first_name"],
 } %>
+
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.name.middle_name.label')
+    text: t("coronavirus_form.questions.name.middle_name.label")
   },
   name: "middle_name",
-  error_message: error_items('middle_name'),
+  error_message: error_items("middle_name"),
   value: session["name"]["middle_name"],
 } %>
+
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.name.last_name.label')
+    text: t("coronavirus_form.questions.name.last_name.label")
   },
   name: "last_name",
-  error_message: error_items('last_name'),
+  error_message: error_items("last_name"),
   value: session["name"]["last_name"],
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/app/views/coronavirus_form/nhs_letter.html.erb
+++ b/app/views/coronavirus_form/nhs_letter.html.erb
@@ -1,6 +1,9 @@
-<% content_for :title do %><%= t('coronavirus_form.nhs_letter.title') %><% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.nhs_letter.title") %>
+<% end %>
+
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.nhs_letter.title') %>" />
+  <meta name="description" content="<%= t('coronavirus_form.questions.nhs_letter.title') %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -13,11 +16,11 @@
   "id": "nhs_letter"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.nhs_letter.title'),
+  heading: t("coronavirus_form.questions.nhs_letter.title"),
   is_page_heading: true,
   name: "nhs_letter",
-  error_message: error_items('nhs_letter'),
-  items: t('coronavirus_form.nhs_letter.options').map do |_, item|
+  error_message: error_items("nhs_letter"),
+  items: t("coronavirus_form.questions.nhs_letter.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],

--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -1,6 +1,9 @@
-<% content_for :title do %><%= t('coronavirus_form.support_address.title') %><% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.support_address.title") %>
+<% end %>
+
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.support_address.title') %>" />
+  <meta name="description" content="<%= t('coronavirus_form.questions.support_address.title') %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -8,12 +11,12 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: t("coronavirus_form.support_address.title"),
+  title: t("coronavirus_form.questions.support_address.title"),
   margin_top: 0
 } %>
 
 <%= render "govuk_publishing_components/components/hint", {
-  text: t("coronavirus_form.support_address.hint"),
+  text: t("coronavirus_form.questions.support_address.hint"),
 } %>
 
 <%= form_tag({},
@@ -23,21 +26,23 @@
 ) do %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.support_address.building_and_street.label')
+    text: t('coronavirus_form.questions.support_address.building_and_street.label')
   },
   name: "building_and_street_line_1",
   type: "text",
   error_message: error_items('building_and_street_line_1'),
   value: session[:support_address]["building_and_line_1"],
 } %>
+
 <%= render "govuk_publishing_components/components/input", {
   name: "building_and_street_line_2",
   error_message: error_items('building_and_street_line_2'),
   value: session[:support_address]["building_and_line_2"],
 } %>
+
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.support_address.town_city.label')
+    text: t('coronavirus_form.questions.support_address.town_city.label')
   },
   name: "town_city",
   type: "text",
@@ -45,9 +50,10 @@
   value: session[:support_address]["town_city"],
   width: 20,
 } %>
+
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.support_address.county.label')
+    text: t('coronavirus_form.questions.support_address.county.label')
   },
   name: "county",
   type: "text",
@@ -55,9 +61,10 @@
   value: session[:support_address]["county"],
   width: 20,
 } %>
+
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.support_address.postcode.label')
+    text: t('coronavirus_form.questions.support_address.postcode.label')
   },
   name: "postcode",
   type: "text",

--- a/app/views/coronavirus_form/temperature_or_cough.html.erb
+++ b/app/views/coronavirus_form/temperature_or_cough.html.erb
@@ -1,6 +1,8 @@
-<% content_for :title do %><%= t('coronavirus_form.temperature_or_cough.title') %><% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.temperature_or_cough.title") %>
+<% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.temperature_or_cough.title') %>" />
+  <meta name="description" content="<%= t('coronavirus_form.questions.temperature_or_cough.title') %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -13,12 +15,12 @@
   "id": "temperature_or_cough"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.temperature_or_cough.title'),
+  heading: t("coronavirus_form.questions.temperature_or_cough.title"),
   is_page_heading: true,
   name: "temperature_or_cough",
-  error_message: error_items('temperature_or_cough'),
-  hint: t('coronavirus_form.temperature_or_cough.hint'),
-  items: t('coronavirus_form.temperature_or_cough.options').map do |_, item|
+  error_message: error_items("temperature_or_cough"),
+  hint: t("coronavirus_form.questions.temperature_or_cough.hint"),
+  items: t("coronavirus_form.questions.temperature_or_cough.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],
@@ -26,5 +28,8 @@
     }
   end
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+  <%= render "govuk_publishing_components/components/button",
+    text: "Continue",
+    margin_bottom: true
+  %>
 <% end %>

--- a/app/views/coronavirus_form/virus_test.html.erb
+++ b/app/views/coronavirus_form/virus_test.html.erb
@@ -1,6 +1,8 @@
-<% content_for :title do %><%= t('coronavirus_form.virus_test.title') %><% end %>
+<% content_for :title do %>
+  <%= t("coronavirus_form.questions.virus_test.title") %>
+<% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.virus_test.title') %>" />
+  <meta name="description" content="<%= t('coronavirus_form.questions.virus_test.title') %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -13,11 +15,11 @@
   "id": "virus_test"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.virus_test.title'),
+  heading: t("coronavirus_form.questions.virus_test.title"),
   is_page_heading: true,
   name: "virus_test",
-  error_message: error_items('virus_test'),
-  items: t('coronavirus_form.virus_test.options').map do |_, item|
+  error_message: error_items("virus_test"),
+  items: t("coronavirus_form.questions.virus_test.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,114 +38,6 @@ en:
       missing_year: "%{field} must include a year"
       missing_month: "%{field} must include a month"
       missing_day: "%{field} must include a day"
-    nhs_letter:
-      title: Have you recently had a letter from the NHS about your situation as someone who's at high risk from coronavirus?
-      options:
-        option_yes:
-          label: "Yes"
-        option_no:
-          label: "No"
-        not_sure:
-          label: "Not sure"
-      custom_select_error: Please select Yes or No
-    medical_conditions:
-      title: Do you have a medical condition that makes you vulnerable to coronavirus?
-      description: |
-        <p class="govuk-body">You’re vulnerable if you:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>have had a solid organ transplant</li>
-          <li>have lung cancer, and you’re getting active chemotherapy or radical radiotherapy</li>
-          <li>have cancer of the blood or bone marrow, at any stage of treatment - for example, leukaemia, lymphoma or myeloma</li>
-          <li>have any cancer for which you’re getting immunotherapy or other continuing antibody treatments</li>
-          <li>have any cancer for which you’re getting a targeted treatment which can affect the immune system - for example, protein kinase inhibitors or PARP inhibitors</li>
-          <li>have had bone marrow or stem cell transplants in the last 6 months, or are still taking immunosuppression drugs</li>
-          <li>have a severe respiratory condition - including cystic fibrosis, severe asthma or severe COPD (Chronic Obstructive Pulmonary Disease)</li>
-          <li>have a rare disease or inborn error of metabolism that significantly increases your risk of infection - for example SCID or homozygous sickle cell</li>
-          <li>are getting an immunosuppression therapy</li>
-          <li>are pregnant and have a significant congenital heart disease</li>
-        </ul>
-      options:
-        option_yes:
-          label: "Yes, I have a medical condition that makes me vulnerable to coronavirus"
-        option_no:
-          label: "No, I do not have a medical condition that makes me vulnerable to coronavirus"
-      custom_select_error: Please select Yes or No
-    temperature_or_cough:
-      title: Do you have a high temperature or a new, continuous cough?
-      hint: A continuous cough means coughing a lot for more than an hour, or 3 or more coughing episodes in 24 hours
-      options:
-        option_yes:
-          label: "Yes"
-        option_no:
-          label: "No"
-      custom_select_error: Please select Yes or No
-    virus_test:
-      title: Have you been tested for coronavirus?
-      options:
-        yes_tested_have_virus:
-          label: Yes, I've been tested and I have coronavirus
-        yes_tested_no_virus:
-          label: Yes, I've been tested and I do not have coronavirus
-        option_no:
-          label: No, I have not been tested
-      custom_select_error: Please select an option
-    carry_supplies:
-      title: Is there someone in the house who's able to carry a delivery of supplies inside?
-      options:
-        option_yes:
-          label: "Yes"
-        option_no:
-          label: "No"
-      custom_select_error: Please select Yes or No
-    date_of_birth:
-      title: What is your date of birth?
-      hint: For example, 31 3 1980
-    dietary_requirements:
-      title: Do you have any special dietary requirements?
-      hint: For example, you're a vegetarian or you have a food allergy.
-      options:
-        option_yes:
-          label: "Yes"
-        option_no:
-          label: "No"
-      custom_select_error: Please select Yes or No
-    essential_supplies:
-      title: Do you have a way of getting essential supplies delivered at the moment?
-      hint: For example, friends or family who can make sure you have enough food.
-      options:
-        option_yes:
-          label: "Yes"
-        option_no:
-          label: "No"
-      custom_select_error: Please select Yes or No
-    addiction:
-      title: "Do you have a history of addiction?"
-      options:
-        option_yes:
-          label: "Yes, I’ve had problems with drug addiction or alcohol addiction (alcoholism)"
-        option_no:
-          label: "No"
-    contact_details:
-      title: "Enter your contact details"
-      hint: "You can use someone else's contact details if that's easier."
-      phone_number_calls:
-        label: "Phone number (for phone calls)"
-      phone_number_texts:
-        label: "Phone number (for text messages)"
-      email:
-        label: "Email address"
-    know_nhs_number:
-      title: "Do you know your NHS number?"
-      hint: |
-        An NHS number is a 10 digit number, like 485 777 3456.
-        <br /><br />
-        You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service.
-      options:
-        option_yes:
-          label: "Yes, I know my NHS number"
-        option_no:
-          label: "No, I do not know my NHS number"
-      custom_select_error: Please select Yes or No
     confirmation:
       title: "Registration complete."
       description: |
@@ -153,32 +45,142 @@ en:
         <p class="govuk-body">If you need essential supplies urgently, call <a class="govuk-link" href="tel:0800 0288327">0800 0288327</a>.</p>
         <p class="govuk-body">If you need medical advice, call the NHS on 111. If it's a medical emergecy, call 999.</p>
         <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
-    name:
-      title: What is your name?
-      first_name:
-        label: First name
-      middle_name:
-        label: Middle names (optional)
-      last_name:
-        label: Last name
-    support_address:
-      title: What is the address where you need support?
-      hint: If you’re applying for someone else, enter the address of the person who needs support.
-      building_and_street:
-        label: Building and street
-      building_and_street_line_1:
-        label: Building and street (First line)
-      town_city:
-        label: Town or city
-      county:
-        label: County
-      postcode:
-        label: Postcode
-    basic_care_needs:
-      title: Are your basic care needs being met at the moment?
-      hint: For example, washing and bathing yourself and keeping your house clean, with the help of friends or family. 
-      options:
-        option_yes:
-          label: "Yes"
-        option_no:
-          label: "No"
+    questions:
+      # These should be in the order that they're asked
+      nhs_letter:
+        title: Have you recently had a letter from the NHS about your situation as someone who's at high risk from coronavirus?
+        options:
+          option_yes:
+            label: "Yes"
+          option_no:
+            label: "No"
+          not_sure:
+            label: "Not sure"
+        custom_select_error: Please select Yes or No
+      medical_conditions:
+        title: Do you have a medical condition that makes you vulnerable to coronavirus?
+        description: |
+          <p class="govuk-body">You’re vulnerable if you:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>have had a solid organ transplant</li>
+            <li>have lung cancer, and you’re getting active chemotherapy or radical radiotherapy</li>
+            <li>have cancer of the blood or bone marrow, at any stage of treatment - for example, leukaemia, lymphoma or myeloma</li>
+            <li>have any cancer for which you’re getting immunotherapy or other continuing antibody treatments</li>
+            <li>have any cancer for which you’re getting a targeted treatment which can affect the immune system - for example, protein kinase inhibitors or PARP inhibitors</li>
+            <li>have had bone marrow or stem cell transplants in the last 6 months, or are still taking immunosuppression drugs</li>
+            <li>have a severe respiratory condition - including cystic fibrosis, severe asthma or severe COPD (Chronic Obstructive Pulmonary Disease)</li>
+            <li>have a rare disease or inborn error of metabolism that significantly increases your risk of infection - for example SCID or homozygous sickle cell</li>
+            <li>are getting an immunosuppression therapy</li>
+            <li>are pregnant and have a significant congenital heart disease</li>
+          </ul>
+        options:
+          option_yes:
+            label: "Yes, I have a medical condition that makes me vulnerable to coronavirus"
+          option_no:
+            label: "No, I do not have a medical condition that makes me vulnerable to coronavirus"
+        custom_select_error: Please select Yes or No
+      temperature_or_cough:
+        title: Do you have a high temperature or a new, continuous cough?
+        hint: A continuous cough means coughing a lot for more than an hour, or 3 or more coughing episodes in 24 hours
+        options:
+          option_yes:
+            label: "Yes"
+          option_no:
+            label: "No"
+        custom_select_error: Please select Yes or No
+      virus_test:
+        title: Have you been tested for coronavirus?
+        options:
+          yes_tested_have_virus:
+            label: Yes, I've been tested and I have coronavirus
+          yes_tested_no_virus:
+            label: Yes, I've been tested and I do not have coronavirus
+          option_no:
+            label: No, I have not been tested
+        custom_select_error: Please select an option
+      carry_supplies:
+        title: Is there someone in the house who's able to carry a delivery of supplies inside?
+        options:
+          option_yes:
+            label: "Yes"
+          option_no:
+            label: "No"
+        custom_select_error: Please select Yes or No
+      date_of_birth:
+        title: What is your date of birth?
+        hint: For example, 31 3 1980
+      dietary_requirements:
+        title: Do you have any special dietary requirements?
+        hint: For example, you're a vegetarian or you have a food allergy.
+        options:
+          option_yes:
+            label: "Yes"
+          option_no:
+            label: "No"
+        custom_select_error: Please select Yes or No
+      essential_supplies:
+        title: Do you have a way of getting essential supplies delivered at the moment?
+        hint: For example, friends or family who can make sure you have enough food.
+        options:
+          option_yes:
+            label: "Yes"
+          option_no:
+            label: "No"
+        custom_select_error: Please select Yes or No
+      addiction:
+        title: "Do you have a history of addiction?"
+        options:
+          option_yes:
+            label: "Yes, I’ve had problems with drug addiction or alcohol addiction (alcoholism)"
+          option_no:
+            label: "No"
+      contact_details:
+        title: "Enter your contact details"
+        hint: "You can use someone else's contact details if that's easier."
+        phone_number_calls:
+          label: "Phone number (for phone calls)"
+        phone_number_texts:
+          label: "Phone number (for text messages)"
+        email:
+          label: "Email address"
+      know_nhs_number:
+        title: "Do you know your NHS number?"
+        hint: |
+          An NHS number is a 10 digit number, like 485 777 3456.
+          <br /><br />
+          You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service.
+        options:
+          option_yes:
+            label: "Yes, I know my NHS number"
+          option_no:
+            label: "No, I do not know my NHS number"
+        custom_select_error: Please select Yes or No
+      name:
+        title: What is your name?
+        first_name:
+          label: First name
+        middle_name:
+          label: Middle names (optional)
+        last_name:
+          label: Last name
+      support_address:
+        title: What is the address where you need support?
+        hint: If you’re applying for someone else, enter the address of the person who needs support.
+        building_and_street:
+          label: Building and street
+        building_and_street_line_1:
+          label: Building and street (First line)
+        town_city:
+          label: Town or city
+        county:
+          label: County
+        postcode:
+          label: Postcode
+      basic_care_needs:
+        title: Are your basic care needs being met at the moment?
+        hint: For example, washing and bathing yourself and keeping your house clean, with the help of friends or family.
+        options:
+          option_yes:
+            label: "Yes"
+          option_no:
+            label: "No"

--- a/spec/controllers/coronavirus_form/addiction_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/addiction_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::AddictionController, type: :controller do
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.addiction.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.addiction.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do

--- a/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::BasicCareNeedsController, type: :controller do
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.basic_care_needs.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.basic_care_needs.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do

--- a/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.carry_supplies.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.carry_supplies.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do

--- a/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.dietary_requirements.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.dietary_requirements.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.essential_supplies.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.essential_supplies.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.know_nhs_number.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.know_nhs_number.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do

--- a/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.medical_conditions.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.medical_conditions.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.nhs_letter.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.nhs_letter.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do

--- a/spec/controllers/coronavirus_form/temperature_or_cough_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/temperature_or_cough_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::TemperatureOrCoughController, type: :controller 
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.temperature_or_cough.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.temperature_or_cough.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do

--- a/spec/controllers/coronavirus_form/virus_test_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/virus_test_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::VirusTestController, type: :controller do
   describe "POST submit" do
     let(:selected) { permitted_values.sample }
     let(:permitted_values) do
-      I18n.t("coronavirus_form.virus_test.options").map { |_, item| item[:label] }
+      I18n.t("coronavirus_form.questions.virus_test.options").map { |_, item| item[:label] }
     end
 
     it "sets session variables" do


### PR DESCRIPTION
To allow for easier plucking of _just_ the questions, all questions are now nested under the key `questions`.

No visual changes, changes to the way the app works - just to the way the internationalisation file is laid out.

The necessary views, controllers, helpers, and tests have been updated to use this new shape. Lots of repetitive changes mean that this is probably worth checking thoroughly.
