### PR TITLE
Fixed out of order heading and added extra margin

### DIFF
--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -17,7 +17,8 @@
 
 <%= render "govuk_publishing_components/components/heading", {
   text: t('check_your_answers.heading'),
-  heading_level: 4
+  heading_level: 2,
+  margin_bottom: 2,
 } %>
 
 <p class="govuk-body">


### PR DESCRIPTION
The heading has been change from level 4 to level 2 because headings should be in order - in this case, an `<h1>` should be followed by `<h2>`.

A bit of extra space was added below the heading to match the prototype.