### PR TITLE
Set session[:nhs_number] to string not hash

### DIFF
--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -6,12 +6,11 @@ class CoronavirusForm::NhsNumberController < ApplicationController
   include FieldValidationHelper
 
   def show
-    session[:nhs_number] ||= {}
     render "coronavirus_form/#{PAGE}"
   end
 
   def submit
-    session[:nhs_number] ||= {}
+    session[:nhs_number] ||= ""
     session[:nhs_number] = sanitize(clean_nhs_number(params["nhs_number"])).presence
 
     invalid_fields = validate_fields(session[:nhs_number])


### PR DESCRIPTION
We are not actually storing the nhs number in a hash in the session.
Setting the default to an empty hash causes the view to display the
literal string "{}" in the textbox by default.

In addition remove the call to initialise the session in `show`.
I don't think we need it because the view is using `session.dig("nhs_number")`
so an absense of value will not throw an error.