### PR TITLE
Add error prefix to errored page titles

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8" />
-    <title><%= yield :title %> - GOV.UK</title>
+    <title><%= t('coronavirus_form.errors.page_title_prefix') if flash[:validation]&.any? %><%= yield :title %> - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="https://www.gov.uk/favicon.ico" type="image/x-icon" />
     <meta name="robots" content="noindex nofollow">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
       <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
   coronavirus_form:
     errors:
+      page_title_prefix: 'Error: '
       heading: "There is a problem"
       radio_field: "Select %{field}"
       checkbox_field: "Select at least one %{field}"


### PR DESCRIPTION
As recommended by the GOV.UK Design System

Closes https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/issues/64