### PR TITLE
Update route for what is your nhs number

### DIFF
--- a/app/views/coronavirus_form/nhs_number.html.erb
+++ b/app/views/coronavirus_form/nhs_number.html.erb
@@ -25,7 +25,7 @@
     <%= render "govuk_publishing_components/components/hint", {
       text: t('coronavirus_form.questions.nhs_number.hint_where_to_find'),
     } %>
-    
+
     <%= render "govuk_publishing_components/components/input", {
       name: "nhs_number",
       label: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,8 +41,8 @@ Rails.application.routes.draw do
   post "/coronavirus-form/know-nhs-number", to: "coronavirus_form/know_nhs_number#submit"
 
   # (v4[sunday]) Question 8.2: What is your NHS number
-  get "/coronavirus-form/what-is-your-nhs-number" => "coronavirus_form/nhs_number#show"
-  post "/coronavirus-form/what-is-your-nhs-number" => "coronavirus_form/nhs_number#submit"
+  get "/coronavirus-form/nhs-number" => "coronavirus_form/nhs_number#show"
+  post "/coronavirus-form/nhs-number" => "coronavirus_form/nhs_number#submit"
 
   # (v4[sunday]) Question 9: Do you have a way of getting essential supplies delivered?
   get "/coronavirus-form/essential-supplies", to: "coronavirus_form/essential_supplies#show"

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { know_nhs_number: "Yes, I do know my NHS number" }
-      expect(response).to redirect_to(coronavirus_form_what_is_your_nhs_number_path)
+      expect(response).to redirect_to(coronavirus_form_nhs_number_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do


### PR DESCRIPTION
Our check answers page assumes the route will be `nhs-number` owing to
the way the logic dasherises the "question" from the yaml file. Currently, it 404s from check answers page.

Ensure this is consistent in the routes.

Remove spurious whitespace in nhs number view.