### PR TITLE
EssentialSupplies: Fix previous path route

### DIFF
--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -34,6 +34,6 @@ private
   NEXT_PAGE = "basic_care_needs"
 
   def previous_path
-    coronavirus_form_what_is_your_nhs_number_path
+    coronavirus_form_nhs_number_path
   end
 end


### PR DESCRIPTION
- This was renamed.
- Surfaced in Sentry in Staging:

```
undefined local variable or method `coronavirus_form_what_is_your_nhs_number_path' for #<CoronavirusForm::EssentialSuppliesController:0x00005556500b5be8>
```