### PR TITLE
Change NHS number input type to number

### DIFF
--- a/app/views/coronavirus_form/nhs_number.html.erb
+++ b/app/views/coronavirus_form/nhs_number.html.erb
@@ -32,6 +32,7 @@
       label: {
         text: t('coronavirus_form.questions.nhs_number.nhs_number.label'),
       },
+      type: "number",
       error_message: error_items('nhs_number'),
       value: session.dig("nhs_number"),
       width: 20,


### PR DESCRIPTION
Trello: https://trello.com/c/qLvXB4r5/106-change-nhs-number-input-to-type-numeric
Closes: https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/issues/77

## What
Make the input for NHS number numeric

Example rendered output:
```
<div class="govuk-form-group">  
  <label for="input-9468206c" class="gem-c-label govuk-label">
    NHS Number
  </label>
  <input name="nhs_number" class="gem-c-input govuk-input govuk-input--width-20" id="input-9468206c" type="text" inputmode="numeric" pattern="[0-9]*" value="">
</div>
```

## Why
Because our NHS colleages, tell us to wash our hands and use [numeric inputs for NHS numbers](https://service-manual.nhs.uk/design-system/patterns/ask-users-for-their-nhs-number).

Also [the design system](https://design-system.service.gov.uk/components/text-input/#numbers) and [publishing components](https://components.publishing.service.gov.uk/component-guide/input/numeric_input) make it easy. 