### PR TITLE
Always route users to enter NHS number

### DIFF
--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -34,6 +34,6 @@ private
   NEXT_PAGE = "basic_care_needs"
 
   def previous_path
-    coronavirus_form_what_is_your_nhs_number_path
+    coronavirus_form_nhs_number_path
   end
 end

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -21,12 +21,12 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+    elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label")
+      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
       redirect_to controller: "coronavirus_form/essential_supplies", action: "show"
-    else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
     end
   end
 

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -37,14 +37,27 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
     end
 
     it "redirects to next step for a permitted response" do
-      post :submit, params: { know_nhs_number: "Yes, I do know my NHS number" }
+      post :submit, params: {
+        know_nhs_number: I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label"),
+      }
+
       expect(response).to redirect_to(coronavirus_form_nhs_number_path)
     end
 
-    it "redirects to check your answers if check your answers previously seen" do
+    it "redirects to what is your NHS number question if check your answers previously seen and answer to question is yes" do
       session[:check_answers_seen] = true
-      post :submit, params: { know_nhs_number: selected }
+      post :submit, params: {
+        know_nhs_number: I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label"),
+      }
 
+      expect(response).to redirect_to(coronavirus_form_nhs_number_path)
+    end
+
+    it "redirects to check your answers if check your answers previously seen and answer to question is no" do
+      session[:check_answers_seen] = true
+      post :submit, params: {
+        know_nhs_number: I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label"),
+      }
       expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
     end
   end


### PR DESCRIPTION
Currently, if a user has seen the "check your answers" page and edits the response to whether they know their NHS number, they will be returned to the "check your answers" page.  This updates the redirect so users are forwarded to enter their NHS number, even if they have seen the "check your answers" page.

Trello card: https://trello.com/c/Q8aycv1O