### PR TITLE
Fix focus state on link on ineligible outside of England page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@ en:
         <li><a class="govuk-link" href="https://gov.wales/coronavirus">Wales</a></li>
       </ul>
       <p class="govuk-body">We won’t store the information you entered.</p>
-      <p class="govuk-body">There's also guidance on <a href="https://www.gov.uk/coronavirus">what you need to do<a/>.</p>
+      <p class="govuk-body">There's also guidance on <a href="https://www.gov.uk/coronavirus" class="govuk-link">what you need to do<a/>.</p>
   privacy_page:
     title: Privacy
     body_text: |


### PR DESCRIPTION
## What

Added `govuk-link` class to give link the correct focus state:

## Why

Link focus states should be consistent and accessible.

## Visual differences

Before:

![Screenshot 2020-03-22 at 17 51 48](https://user-images.githubusercontent.com/1732331/77256398-df2d3500-6c65-11ea-87c7-aa2d6053de85.png)

After:

![Screenshot 2020-03-22 at 17 51 58](https://user-images.githubusercontent.com/1732331/77256402-e3f1e900-6c65-11ea-984e-b410c8ca1c25.png)

