### PR TITLE
Ensure the NHS number doesnt get reformated

### DIFF
--- a/app/views/coronavirus_form/know_nhs_number.html.erb
+++ b/app/views/coronavirus_form/know_nhs_number.html.erb
@@ -4,6 +4,8 @@
 
 <% content_for :meta_tags do %>
   <meta name="description" content="<%= t("coronavirus_form.questions.know_nhs_number.title") %>" />
+  <%# stop iOS treating the NHS number as a phone number %>
+  <meta name="format-detection" content="telephone=no" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -33,4 +35,3 @@
     } %>
     <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
     <% end %>
-    

--- a/app/views/coronavirus_form/nhs_number.html.erb
+++ b/app/views/coronavirus_form/nhs_number.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title do %><%= t('coronavirus_form.questions.nhs_number.title') %><% end %>
     <% content_for :meta_tags do %>
       <meta name="description" content="<%= t('coronavirus_form.questions.nhs_number.title') %>" />
+      <%# stop iOS treating the NHS number as a phone number %>
+      <meta name="format-detection" content="telephone=no" />
     <% end %>
 
     <% content_for :back_link do %>


### PR DESCRIPTION
This happens on iOS and is a recommendation from the NHS team.

> add meta name="format-detection" content="telephone=no" to your page to stop iOS treating the NHS number as a phone number (but this means that iOS will not recognise any phone numbers on the page)

https://service-manual.nhs.uk/design-system/patterns/ask-users-for-their-nhs-number