### PR TITLE
Remove /coronavirus-form from all routes

### DIFF
--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -34,6 +34,6 @@ private
   NEXT_PAGE = "dietary_requirements"
 
   def previous_path
-    coronavirus_form_essential_supplies_path
+    essential_supplies_path
   end
 end

--- a/app/controllers/coronavirus_form/carry_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/carry_supplies_controller.rb
@@ -34,6 +34,6 @@ private
   NEXT_PAGE = "check_answers"
 
   def previous_path
-    coronavirus_form_dietary_requirements_path
+    dietary_requirements_path
   end
 end

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -35,6 +35,6 @@ private
   NEXT_PAGE = "medical_conditions"
 
   def previous_path
-    coronavirus_form_support_address_path
+    support_address_path
   end
 end

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -39,6 +39,6 @@ private
   NEXT_PAGE = "support_address"
 
   def previous_path
-    coronavirus_form_name_path
+    name_path
   end
 end

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -34,6 +34,6 @@ private
   NEXT_PAGE = "carry_supplies"
 
   def previous_path
-    coronavirus_form_basic_care_needs_path
+    basic_care_needs_path
   end
 end

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -34,6 +34,6 @@ private
   NEXT_PAGE = "basic_care_needs"
 
   def previous_path
-    coronavirus_form_nhs_number_path
+    nhs_number_path
   end
 end

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -36,6 +36,6 @@ private
   NEXT_PAGE = "nhs_number"
 
   def previous_path
-    coronavirus_form_medical_conditions_path
+    medical_conditions_path
   end
 end

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -36,6 +36,6 @@ private
   NEXT_PAGE = "know_nhs_number"
 
   def previous_path
-    coronavirus_form_contact_details_path
+    contact_details_path
   end
 end

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -44,6 +44,6 @@ private
   end
 
   def previous_path
-    coronavirus_form_nhs_letter_path
+    nhs_letter_path
   end
 end

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -34,6 +34,6 @@ private
   NEXT_PAGE = "name"
 
   def previous_path
-    coronavirus_form_live_in_england_path
+    live_in_england_path
   end
 end

--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -48,6 +48,6 @@ private
   NEXT_PAGE = "essential_supplies"
 
   def previous_path
-    coronavirus_form_know_nhs_number_path
+    know_nhs_number_path
   end
 end

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -81,6 +81,6 @@ private
   end
 
   def previous_path
-    coronavirus_form_date_of_birth_path
+    date_of_birth_path
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,70 +6,70 @@ Rails.application.routes.draw do
 
   get "/" => redirect("https://www.gov.uk/coronavirus-extremely-vulnerable")
 
-  get "/coronavirus-form/privacy", to: "coronavirus_form/privacy#show"
+  get "/privacy", to: "coronavirus_form/privacy#show"
 
   # (v4[sunday]) Question 1: Do you live in England?
-  get "/coronavirus-form/live-in-england", to: "coronavirus_form/live_in_england#show"
-  post "/coronavirus-form/live-in-england", to: "coronavirus_form/live_in_england#submit"
+  get "/live-in-england", to: "coronavirus_form/live_in_england#show"
+  post "/live-in-england", to: "coronavirus_form/live_in_england#submit"
 
   # (v4[sunday]) Question 2: Have you recently had a letter from the NHS...
-  get "/coronavirus-form/nhs-letter", to: "coronavirus_form/nhs_letter#show"
-  post "/coronavirus-form/nhs-letter", to: "coronavirus_form/nhs_letter#submit"
+  get "/nhs-letter", to: "coronavirus_form/nhs_letter#show"
+  post "/nhs-letter", to: "coronavirus_form/nhs_letter#submit"
 
   # (v4[sunday]) Question 3: What is your name?
-  get "/coronavirus-form/name", to: "coronavirus_form/name#show"
-  post "coronavirus-form/name", to: "coronavirus_form/name#submit"
+  get "/name", to: "coronavirus_form/name#show"
+  post "/name", to: "coronavirus_form/name#submit"
 
   # (v4[sunday]) Question 4: What is your date of birth?
-  get "/coronavirus-form/date-of-birth", to: "coronavirus_form/date_of_birth#show"
-  post "/coronavirus-form/date-of-birth", to: "coronavirus_form/date_of_birth#submit"
+  get "/date-of-birth", to: "coronavirus_form/date_of_birth#show"
+  post "/date-of-birth", to: "coronavirus_form/date_of_birth#submit"
 
   # (v4[sunday]) Question 5: Address where support is needed
-  get "/coronavirus-form/support-address" => "coronavirus_form/support_address#show"
-  post "/coronavirus-form/support-address" => "coronavirus_form/support_address#submit"
+  get "/support-address" => "coronavirus_form/support_address#show"
+  post "/support-address" => "coronavirus_form/support_address#submit"
 
   # (v4[sunday]) Question 6: Enter your contact details
-  get "/coronavirus-form/contact-details", to: "coronavirus_form/contact_details#show"
-  post "/coronavirus-form/contact-details", to: "coronavirus_form/contact_details#submit"
+  get "/contact-details", to: "coronavirus_form/contact_details#show"
+  post "/contact-details", to: "coronavirus_form/contact_details#submit"
 
   # (v4[sunday]) Question 7: Do you have a medical condition that makes you vulnerable to coronavirus?
-  get "/coronavirus-form/medical-conditions", to: "coronavirus_form/medical_conditions#show"
-  post "coronavirus-form/medical-conditions", to: "coronavirus_form/medical_conditions#submit"
+  get "/medical-conditions", to: "coronavirus_form/medical_conditions#show"
+  post "/medical-conditions", to: "coronavirus_form/medical_conditions#submit"
 
   # (v4[sunday]) Question 8.1: Do you know your NHS number?
-  get "/coronavirus-form/know-nhs-number", to: "coronavirus_form/know_nhs_number#show"
-  post "/coronavirus-form/know-nhs-number", to: "coronavirus_form/know_nhs_number#submit"
+  get "/know-nhs-number", to: "coronavirus_form/know_nhs_number#show"
+  post "/know-nhs-number", to: "coronavirus_form/know_nhs_number#submit"
 
   # (v4[sunday]) Question 8.2: What is your NHS number
-  get "/coronavirus-form/nhs-number" => "coronavirus_form/nhs_number#show"
-  post "/coronavirus-form/nhs-number" => "coronavirus_form/nhs_number#submit"
+  get "/nhs-number" => "coronavirus_form/nhs_number#show"
+  post "/nhs-number" => "coronavirus_form/nhs_number#submit"
 
   # (v4[sunday]) Question 9: Do you have a way of getting essential supplies delivered?
-  get "/coronavirus-form/essential-supplies", to: "coronavirus_form/essential_supplies#show"
-  post "coronavirus-form/essential-supplies", to: "coronavirus_form/essential_supplies#submit"
+  get "/essential-supplies", to: "coronavirus_form/essential_supplies#show"
+  post "/essential-supplies", to: "coronavirus_form/essential_supplies#submit"
 
   # (v4[sunday]) Question 10: Are your basic care needs being met at the moment?
-  get "/coronavirus-form/basic-care-needs", to: "coronavirus_form/basic_care_needs#show"
-  post "coronavirus-form/basic-care-needs", to: "coronavirus_form/basic_care_needs#submit"
+  get "/basic-care-needs", to: "coronavirus_form/basic_care_needs#show"
+  post "/basic-care-needs", to: "coronavirus_form/basic_care_needs#submit"
 
   # (v4[sunday]) Question 11: Do you have any special dietary requirements?
-  get "/coronavirus-form/dietary-requirements", to: "coronavirus_form/dietary_requirements#show"
-  post "coronavirus-form/dietary-requirements", to: "coronavirus_form/dietary_requirements#submit"
+  get "/dietary-requirements", to: "coronavirus_form/dietary_requirements#show"
+  post "/dietary-requirements", to: "coronavirus_form/dietary_requirements#submit"
 
   # (v4[sunday]) Question 12: Is there someone in the house who's able to carry a delivery of supplies inside?
-  get "/coronavirus-form/carry-supplies", to: "coronavirus_form/carry_supplies#show"
-  post "coronavirus-form/carry-supplies", to: "coronavirus_form/carry_supplies#submit"
+  get "/carry-supplies", to: "coronavirus_form/carry_supplies#show"
+  post "/carry-supplies", to: "coronavirus_form/carry_supplies#submit"
 
   # Check answers page
-  get "/coronavirus-form/check-your-answers" => "coronavirus_form/check_answers#show"
-  post "/coronavirus-form/check-your-answers" => "coronavirus_form/check_answers#submit"
+  get "/check-your-answers" => "coronavirus_form/check_answers#show"
+  post "/check-your-answers" => "coronavirus_form/check_answers#submit"
 
   # Not eligible for supplies
-  get "/coronavirus-form/not-eligible-medical" => "coronavirus_form/not_eligible_medical#show"
+  get "/not-eligible-medical" => "coronavirus_form/not_eligible_medical#show"
 
   # Person isn't eligible if not in England
-  get "/coronavirus-form/not-eligible-england" => "coronavirus_form/not_eligible_england#show"
+  get "/not-eligible-england" => "coronavirus_form/not_eligible_england#show"
 
   # Final page
-  get "/coronavirus-form/confirmation" => "coronavirus_form/confirmation#show"
+  get "/confirmation" => "coronavirus_form/confirmation#show"
 end

--- a/features/step_definitions/basic_care_needs_steps.rb
+++ b/features/step_definitions/basic_care_needs_steps.rb
@@ -1,8 +1,8 @@
 When("I visit the basic care needs page") do
-  visit coronavirus_form_basic_care_needs_path
+  visit basic_care_needs_path
 end
 
 Then("I will be redirected to the dietary requirements page") do
   expect(page.status_code).to eq(200)
-  expect(page).to have_current_path(coronavirus_form_dietary_requirements_path)
+  expect(page).to have_current_path(dietary_requirements_path)
 end

--- a/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe CoronavirusForm::BasicCareNeedsController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { basic_care_needs: selected }
-      expect(response).to redirect_to(coronavirus_form_dietary_requirements_path)
+      expect(response).to redirect_to(dietary_requirements_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { basic_care_needs: "Yes" }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { carry_supplies: selected }
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "validates a valid option is chosen" do
@@ -47,7 +47,7 @@ RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
       session[:check_answers_seen] = true
       post :submit, params: { carry_supplies: selected }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: params
-      expect(response).to redirect_to(coronavirus_form_medical_conditions_path)
+      expect(response).to redirect_to(medical_conditions_path)
     end
 
     it "does not move to next step with an invalid email address" do
@@ -42,7 +42,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       session[:check_answers_seen] = true
       post :submit, params: params
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: params
-      expect(response).to redirect_to(coronavirus_form_support_address_path)
+      expect(response).to redirect_to(support_address_path)
     end
 
     context "params unset" do
@@ -60,7 +60,7 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
       session[:check_answers_seen] = true
       post :submit, params: params
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { dietary_requirements: selected }
-      expect(response).to redirect_to(coronavirus_form_carry_supplies_path)
+      expect(response).to redirect_to(carry_supplies_path)
     end
 
     it "validates a valid option is chosen" do
@@ -45,7 +45,7 @@ RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller
       session[:check_answers_seen] = true
       post :submit, params: { dietary_requirements: selected }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { essential_supplies: selected }
-      expect(response).to redirect_to(coronavirus_form_basic_care_needs_path)
+      expect(response).to redirect_to(basic_care_needs_path)
     end
 
     it "validates a valid option is chosen" do
@@ -45,7 +45,7 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
       session[:check_answers_seen] = true
       post :submit, params: { essential_supplies: selected }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
         know_nhs_number: I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label"),
       }
 
-      expect(response).to redirect_to(coronavirus_form_nhs_number_path)
+      expect(response).to redirect_to(nhs_number_path)
     end
 
     it "redirects to what is your NHS number question if check your answers previously seen and answer to question is yes" do
@@ -50,7 +50,7 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
         know_nhs_number: I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label"),
       }
 
-      expect(response).to redirect_to(coronavirus_form_nhs_number_path)
+      expect(response).to redirect_to(nhs_number_path)
     end
 
     it "redirects to check your answers if check your answers previously seen and answer to question is no" do
@@ -58,7 +58,7 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
       post :submit, params: {
         know_nhs_number: I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label"),
       }
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/live_in_england_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/live_in_england_controller_spec.rb
@@ -38,19 +38,19 @@ RSpec.describe CoronavirusForm::LiveInEnglandController, type: :controller do
 
     it "redirects to next step for a yes response" do
       post :submit, params: { live_in_england: "Yes" }
-      expect(response).to redirect_to(coronavirus_form_nhs_letter_path)
+      expect(response).to redirect_to(nhs_letter_path)
     end
 
     it "redirects to ineligible page for a no response" do
       post :submit, params: { live_in_england: "No" }
-      expect(response).to redirect_to(coronavirus_form_not_eligible_england_path)
+      expect(response).to redirect_to(not_eligible_england_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { live_in_england: "Yes" }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
 
     it "redirects to next step for a yes response" do
       post :submit, params: { medical_conditions: I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes.label") }
-      expect(response).to redirect_to(coronavirus_form_know_nhs_number_path)
+      expect(response).to redirect_to(know_nhs_number_path)
     end
 
     it "redirects to ineligible page for a no response" do
       post :submit, params: { medical_conditions: I18n.t("coronavirus_form.questions.medical_conditions.options.option_no.label") }
-      expect(response).to redirect_to(coronavirus_form_not_eligible_medical_path)
+      expect(response).to redirect_to(not_eligible_medical_path)
     end
 
     it "validates a valid option is chosen" do
@@ -50,7 +50,7 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
       session[:check_answers_seen] = true
       post :submit, params: { medical_conditions: selected }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
       post :submit, params: params.except("middle_name")
 
       expect(session[session_key]).to eq person.merge("middle_name" => nil)
-      expect(response).to redirect_to(coronavirus_form_date_of_birth_path)
+      expect(response).to redirect_to(date_of_birth_path)
     end
 
     it "validates a valid option is chosen" do
@@ -64,14 +64,14 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: params
-      expect(response).to redirect_to(coronavirus_form_date_of_birth_path)
+      expect(response).to redirect_to(date_of_birth_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: params
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { nhs_letter: selected }
-      expect(response).to redirect_to(coronavirus_form_name_path)
+      expect(response).to redirect_to(name_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { nhs_letter: "Yes" }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe CoronavirusForm::NhsNumberController, type: :controller do
 
     it "redirects to next step for a valid NHS number" do
       post :submit, params: { nhs_number: valid_nhs_number }
-      expect(response).to redirect_to(coronavirus_form_essential_supplies_path)
+      expect(response).to redirect_to(essential_supplies_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { nhs_number: valid_nhs_number }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
   let(:current_template) { "coronavirus_form/support_address" }
   let(:session_key) { :support_address }
-  let(:next_page) { coronavirus_form_contact_details_path }
+  let(:next_page) { contact_details_path }
 
   describe "GET show" do
     it "renders the form" do


### PR DESCRIPTION
Form questions, confirmation, etc will now be served from the root.