### PR TITLE
Always redirect to not eligible page if user lives outside England

### DIFF
--- a/app/controllers/coronavirus_form/live_in_england_controller.rb
+++ b/app/controllers/coronavirus_form/live_in_england_controller.rb
@@ -21,10 +21,10 @@ class CoronavirusForm::LiveInEnglandController < ApplicationController
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
-    elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
     elsif session[:live_in_england] == I18n.t("coronavirus_form.questions.live_in_england.options.option_no.label")
       redirect_to controller: "coronavirus_form/not_eligible_england", action: "show"
+    elsif session["check_answers_seen"]
+      redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else
       redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
     end

--- a/spec/controllers/coronavirus_form/live_in_england_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/live_in_england_controller_spec.rb
@@ -52,5 +52,12 @@ RSpec.describe CoronavirusForm::LiveInEnglandController, type: :controller do
 
       expect(response).to redirect_to(check_your_answers_path)
     end
+
+    it "redirects to ineligible page for a no response when check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: { live_in_england: "No" }
+
+      expect(response).to redirect_to(not_eligible_england_path)
+    end
   end
 end


### PR DESCRIPTION
Currently, a user who has checked their answers can change their response to "Do you live in England?" to "no", but then submit the form.  This changes the logic so they will always be sent to an ineligible notice.

Trello card: https://trello.com/c/pQvPmehz

Fixes #102 