### PR TITLE
Add postcode validation

### DIFF
--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -44,6 +44,7 @@ private
     [
       validate_missing_fields(support_address),
       validate_conditionally_present_fields(support_address),
+      validate_postcode("postcode", support_address["postcode"]),
     ].flatten.uniq
   end
 

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -81,7 +81,9 @@ module FieldValidationHelper
   end
 
   def validate_postcode(field, postcode)
-    if postcode =~ /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/i
+    if postcode.blank?
+      []
+    elsif postcode =~ /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/i
       []
     else
       [{ field: field.to_s, text: t("coronavirus_form.errors.postcode_format") }]

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -75,6 +75,33 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       expect(response).to redirect_to(next_page)
     end
 
+    it "redirects to next step when postcode is valid" do
+      valid_postcodes = [
+        "AA9A 9AA",
+        "A9A 9AA",
+        "A9 9AA",
+        "A99 9AA",
+        "AA9 9AA",
+        "AA99 9AA",
+        "BFPO 1",
+        "BFPO 9",
+      ]
+
+      valid_postcodes.each do |postcode|
+        params["postcode"] = postcode
+        post :submit, params: params
+
+        expect(response).to redirect_to(next_page)
+      end
+    end
+
+    it "does not redirect to next step when postcode is invalid" do
+      params["postcode"] = "AAA1 1AA"
+      post :submit, params: params
+
+      expect(response).to render_template(current_template)
+    end
+
     described_class::REQUIRED_FIELDS.each do |field|
       it "requires that key #{field} be provided" do
         post :submit, params: params.except(field)


### PR DESCRIPTION
Adds validation for postcode entered on the support address question.  Maintains the existing conditional validation where a user can enter either a county or postcode or both.

Trello card: https://trello.com/c/EqVwf3E1

Fixes: #71 