### PR TITLE
Add visually hidden label to address form

### DIFF
--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -36,6 +36,9 @@
   value: session[:support_address]["building_and_street_line_1"],
 } %>
 
+<label class="govuk-visually-hidden" for="building_and_street_line_2">
+  <%= t('coronavirus_form.questions.support_address.building_and_street_line_2.label') %>
+</label>
 <%= render "govuk_publishing_components/components/input", {
   id: "building_and_street_line_2",
   name: "building_and_street_line_2",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,8 @@ en:
         building_and_street_line_1:
           label: Building and street (First line)
           custom_error: Enter a building and street
+        building_and_street_line_2:
+          label: Building and street (Second line)
         town_city:
           label: Town or city
           custom_error: Enter a town or city


### PR DESCRIPTION
This is what is recommended by the Design System.

Ensures that screen readers know what this field is for.

Closes https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/issues/116