### PR TITLE
Make the asset pipeline apply cache control

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,15 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  if ENV["RAILS_SERVE_STATIC_FILES"].present?
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = {
+      "Cache-Control" => "public, s-maxage=86400, max-age=86400",
+      "Expires" => 1.day.from_now.to_formatted_s(:rfc822),
+    }
+  else
+    config.public_file_server.enabled = false
+  end
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
What
---

Not sure if this is needed as I'm out of the loop on the CDN stuff:

- Add cache control headers to asset pipeline
- Cache assets for 24h
- This will get picked up by CloudFront, so we can keep DefaultTTL to 0