### PR TITLE
Always redirect to not eligible page for no medical conditions

### DIFF
--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -21,10 +21,10 @@ class CoronavirusForm::MedicalConditionsController < ApplicationController
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
-    elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
     elsif session[:medical_conditions] == I18n.t("coronavirus_form.questions.medical_conditions.options.option_no.label")
       redirect_to controller: "coronavirus_form/not_eligible_medical", action: "show"
+    elsif session["check_answers_seen"]
+      redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else
       redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
     end

--- a/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
@@ -48,9 +48,16 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { medical_conditions: selected }
+      post :submit, params: { medical_conditions: I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes.label") }
 
       expect(response).to redirect_to(check_your_answers_path)
+    end
+
+    it "redirects to ineligible page for a no response when check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: { medical_conditions: I18n.t("coronavirus_form.questions.medical_conditions.options.option_no.label") }
+
+      expect(response).to redirect_to(not_eligible_medical_path)
     end
   end
 end


### PR DESCRIPTION
Currently, a user who has checked their answers can change their response to "Do you have a medical condition that makes you extremely vulnerable to coronavirus?" to "no", but then submit the form.

This changes the logic so they will always be sent to an ineligible notice.

Trello card: https://trello.com/c/1YxCVrrE