### PR TITLE
Fix hint overrided colour

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,6 @@
 // The GOV.UK Design System team are aware of issues with lighter grey text for some disabled users
 // For example those with dyslexia or visual impairments.
 // Since this service is targetted at vulnerable people we're setting hint text to a darker colour to be safe.
-.gem-c-hint {
+.govuk-hint {
     color: $govuk-text-colour
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,7 +249,7 @@ en:
       dietary_requirements:
         title: Do you have any special dietary requirements?
         hint: |
-          <p class="govuk-hint app-hint">For example, you’re a vegetarian or you have a food allergy.</p>
+          <p class="govuk-hint">For example, you’re a vegetarian or you have a food allergy.</p>
           <p class="govuk-inset-text">For now, food supplies will be delivered in standard packages. Check the ingredients lists carefully if you have a food allergy or follow a special diet. If you have special dietary requirements, some of the food may not meet them.</p>
         options:
           option_yes:


### PR DESCRIPTION
GOV.UK Publishing Components uses the following classes for a hint:

.gem-c-hint .govuk-hint

https://components.publishing.service.gov.uk/component-guide/hint

Update the CSS to target the GOV.UK Frontend class instead of the gem
class which is not always used, for example when in the translations
content.