### PR TITLE
Add autocomplete values where possible

### DIFF
--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -33,6 +33,8 @@
   },
   value: session.dig("contact_details", "phone_number_calls"),
   width: 20,
+  type: "tel",
+  autocomplete: "tel",
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -42,6 +44,8 @@
   },
   value: session.dig("contact_details", "phone_number_texts"),
   width: 20,
+  type: "tel",
+  autocomplete: "tel",
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -50,6 +54,8 @@
     text: t("coronavirus_form.questions.contact_details.email.label"),
   },
   value: session.dig("contact_details", "email"),
+  type: "email",
+  autocomplete: "email",
 } %>
 
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -30,21 +30,24 @@
       id: "date_of_birth-day",
       name: "day",
       width: 2,
-      value: session["date_of_birth"]["day"]
+      value: session["date_of_birth"]["day"],
+      autocomplete: "bday-day",
     },
     {
       label: "Month",
       id: "date_of_birth-month",
       name: "month",
       width: 2,
-      value: session["date_of_birth"]["month"]
+      value: session["date_of_birth"]["month"],
+      autocomplete: "bday-month",
     },
     {
       label: "Year",
       id: "date_of_birth-year",
       name: "year",
       width: 4,
-      value: session["date_of_birth"]["year"]
+      value: session["date_of_birth"]["year"],
+      autocomplete: "bday-year",
     }
   ]
 } %>

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -29,6 +29,7 @@
   name: "first_name",
   error_message: error_items("first_name"),
   value: session["name"]["first_name"],
+  autocomplete: "given-name",
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -49,6 +50,7 @@
   name: "last_name",
   error_message: error_items("last_name"),
   value: session["name"]["last_name"],
+  autocomplete: "family-name",
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -34,6 +34,7 @@
   type: "text",
   error_message: error_items('building_and_street_line_1'),
   value: session[:support_address]["building_and_street_line_1"],
+  autocomplete: "address-line1",
 } %>
 
 <label class="govuk-visually-hidden" for="building_and_street_line_2">
@@ -44,6 +45,7 @@
   name: "building_and_street_line_2",
   error_message: error_items('building_and_street_line_2'),
   value: session[:support_address]["building_and_street_line_2"],
+  autocomplete: "address-line2",
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -56,6 +58,7 @@
   error_message: error_items('town_city'),
   value: session[:support_address]["town_city"],
   width: 20,
+  autocomplete: "address-level2",
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -80,6 +83,7 @@
   error_message: error_items('postcode'),
   value: session[:support_address]["postcode"],
   width: 10,
+  autocomplete: "postal-code",
 } %>
 
 <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>


### PR DESCRIPTION
Also includes setting the type for certain fields, which will improve
the keyboard usability on mobile.

Check the following patterns to confirm the changes are correct:

- [date of birth](https://design-system.service.gov.uk/patterns/dates/)
- [names](https://design-system.service.gov.uk/patterns/names/)
- [emails](https://design-system.service.gov.uk/patterns/email-addresses/)
- [phones](https://design-system.service.gov.uk/patterns/telephone-numbers/)
- [addresses](https://design-system.service.gov.uk/patterns/addresses/)

Improves https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/issues/91 , we cant use spellcheck=false as the input macros do not allow it yet.