### PR TITLE
Link to the "privacy notice" in the footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,16 @@
         </div>
       </main>
     </div>
-    <%= render "govuk_publishing_components/components/layout_footer" %>
+    <%= render "govuk_publishing_components/components/layout_footer", {
+      meta: {
+        items: [
+          {
+            href: "/privacy",
+            text: t("privacy_notice.label")
+          },
+        ]
+      }
+    } %>
     <%= javascript_include_tag "application" %>
   </body>
 </html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,6 @@
 en:
+  privacy_notice:
+    label: Privacy notice
   check_your_answers:
     title: Check your answers before sending your application
     heading: Now send your application


### PR DESCRIPTION
- Taken from https://components.publishing.service.gov.uk/component-guide/layout_footer.

Trello: https://trello.com/c/8oKXnoPt/111-footer-should-link-to-privacy-notice

Screenshot:

<img width="1492" alt="Screenshot 2020-03-22 at 21 10 05" src="https://user-images.githubusercontent.com/355033/77260795-042fa100-6c82-11ea-96b1-6f1e291a1a1e.png">
