### PR TITLE
Redirect to correctly if user doesn't know NHS number

### DIFF
--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -34,6 +34,8 @@ private
   NEXT_PAGE = "basic_care_needs"
 
   def previous_path
-    nhs_number_path
+    return nhs_number_path if session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label")
+
+    know_nhs_number_path
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/FVbRtlJU/114-nhs-number-no-back-you-go-to-the-nhs-number-entry

Skip the "What is your NHS number" page, when the user clicks "back" if they've already
said that they don't know their NHS number.