### PR TITLE
Set the nhs_number to nil if the user changes their answer

### DIFF
--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -12,6 +12,8 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
     know_nhs_number = sanitize(params[:know_nhs_number]).presence
     session[:know_nhs_number] = know_nhs_number
 
+    session[:nhs_number] = nil if I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
+
     invalid_fields = validate_radio_field(
       PAGE,
       radio: know_nhs_number,

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -60,5 +60,15 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
       }
       expect(response).to redirect_to(check_your_answers_path)
     end
+
+    it "clears the nhs_number if the user changes their answer to No" do
+      session[:nhs_number] = "485 777 3456"
+
+      post :submit, params: {
+        know_nhs_number: I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label"),
+      }
+
+      expect(session[:nhs_number]).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/7nWLsSsg/121-remove-the-nhs-number-from-the-session-if-the-user-changes-their-answer-to-do-you-know-your-nhs-number

Remove the NHS number from the session if the answer to "Do you know your NHS number" is "No".

We were in a situation where the user initially answered "Yes" to "Do you know your NHS number", entered
their nhs number, and then on the check-answer screen, changed their answer "No", but the nhs number they'd
previously entered was still being displayed because it wasn't being cleared from the session.