### PR TITLE
Exclude all config from rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,4 +9,5 @@ inherit_mode:
 
 Metrics/BlockLength:
   Exclude:
-    - config/routes.rb
+    - config/**/*
+    - config/environments/production.rb


### PR DESCRIPTION
Should unblock: https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/126