### PR TITLE
Remove production config file from exclusions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,4 +10,3 @@ inherit_mode:
 Metrics/BlockLength:
   Exclude:
     - config/**/*
-    - config/environments/production.rb


### PR DESCRIPTION
I had to add this in to get it passed the linter, but now it can be removed.