### PR TITLE
Set secret key base in concourse

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -45,6 +45,7 @@ jobs:
           BASIC_AUTH_PASSWORD: ((basic-auth-password))
           AWS_ACCESS_KEY_ID: ((aws-access-key-id))
           AWS_SECRET_ACCESS_KEY: ((aws-secret-access-key))
+          SECRET_KEY_BASE: ((secret-key-base-staging))
           AWS_DYNAMODB_SUBMISSIONS_TABLE_NAME: coronavirus-vulnerable-people-staging
           HOSTNAME: govuk-coronavirus-vulnerable-people-form-stg
 
@@ -73,6 +74,7 @@ jobs:
           BASIC_AUTH_PASSWORD: ((basic-auth-password))
           AWS_ACCESS_KEY_ID: ((aws-access-key-id-prod))
           AWS_SECRET_ACCESS_KEY: ((aws-secret-access-key-prod))
+          SECRET_KEY_BASE: ((secret-key-base-prod))
           AWS_DYNAMODB_SUBMISSIONS_TABLE_NAME: coronavirus-vulnerable-people-prod
           HOSTNAME: govuk-coronavirus-vulnerable-people-form-prod
 

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -13,6 +13,7 @@ params:
   CF_PASSWORD: ((paas-password))
   CF_ORG: govuk_development
   SENTRY_DSN: https://((sentry-dsn))
+  SECRET_KEY_BASE:
   CF_STARTUP_TIMEOUT:
   CF_SPACE:
   HOSTNAME:
@@ -42,6 +43,7 @@ run:
       cf set-env govuk-coronavirus-vulnerable-people-form SENTRY_DSN "$SENTRY_DSN"
       cf set-env govuk-coronavirus-vulnerable-people-form AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID"
       cf set-env govuk-coronavirus-vulnerable-people-form AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
+      cf set-env govuk-coronavirus-vulnerable-people-form SECRET_KEY_BASE "$SECRET_KEY_BASE"
 
       cf v3-zdt-push govuk-coronavirus-vulnerable-people-form --wait-for-deploy-complete --no-route
       cf map-route govuk-coronavirus-vulnerable-people-form cloudapps.digital --hostname "$HOSTNAME"

--- a/manifest.yml
+++ b/manifest.yml
@@ -15,5 +15,6 @@ applications:
     # BASIC_AUTH_PASSWORD: '' # set by concourse with cf set-env
     # AWS_ACCESS_KEY_ID: '' # set by concourse with cf set-env
     # AWS_SECRET_ACCESS_KEY: '' # set by concourse with cf set-env
+    # SECRET_KEY_BASE: '' # set by concourse with cf set-env
     # AWS_DYNAMODB_SUBMISSIONS_TABLE_NAME: '' # set by concourse with cf set-env
 


### PR DESCRIPTION
This is the key which is used to sign the session cookie, so it should
be the same across all instances of the app. Best thing seems to be to
stick it in a concourse secret and then cf set-env it.