### PR TITLE
Ensure error summary always links to first input

### DIFF
--- a/app/views/coronavirus_form/basic_care_needs.erb
+++ b/app/views/coronavirus_form/basic_care_needs.erb
@@ -12,7 +12,6 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulnerable-people-basic-care-needs",
   "data-question-key": "basic_care_needs",
-  "id": "basic_care_needs",
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
@@ -21,8 +20,9 @@
   is_page_heading: true,
   name: "basic_care_needs",
   error_message: error_items("basic_care_needs"),
-  items: t("coronavirus_form.questions.basic_care_needs.options").map do |_, item|
+  items: t("coronavirus_form.questions.basic_care_needs.options").map.with_index do |(_, item), index|
     {
+      id: ("basic_care_needs" if index == 0),
       value: item[:label],
       text: item[:label],
       checked: session[:basic_care_needs] == item[:label],

--- a/app/views/coronavirus_form/carry_supplies.html.erb
+++ b/app/views/coronavirus_form/carry_supplies.html.erb
@@ -13,7 +13,6 @@
     <%= form_tag({},
       "data-module": "track-coronavirus-form-vulnerable-people-carry-supplies",
       "data-question-key": "carry_supplies",
-      "id": "carry_supplies",
       "novalidate": "true"
     ) do %>
     <%= render "govuk_publishing_components/components/radio", {
@@ -21,8 +20,9 @@
       is_page_heading: true,
       name: "carry_supplies",
       error_message: error_items("carry_supplies"),
-      items: t("coronavirus_form.questions.carry_supplies.options").map do |_, item|
+      items: t("coronavirus_form.questions.carry_supplies.options").map.with_index do |(_, item), index|
         {
+          id: ("carry_supplies" if index == 0),
           value: item[:label],
           text: item[:label],
           checked: session[:carry_supplies] == item[:label],

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -13,7 +13,6 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulnerable-people-contact_details",
   "data-question-key": "contact_details",
-  "id": "contact_details",
   "novalidate": "true"
 ) do %>
 
@@ -49,6 +48,7 @@
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
+  id: "email",
   name: "email",
   label: {
     text: t("coronavirus_form.questions.contact_details.email.label"),

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -12,7 +12,6 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulnerable-people-date-of-birth",
   "data-question-key": "date_of_birth",
-  "id": "date_of_birth",
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/title", {

--- a/app/views/coronavirus_form/dietary_requirements.html.erb
+++ b/app/views/coronavirus_form/dietary_requirements.html.erb
@@ -13,7 +13,6 @@
     <%= form_tag({},
       "data-module": "track-coronavirus-form-vulnerable-people-dietary-requirements",
       "data-question-key": "dietary_requirements",
-      "id": "dietary_requirements",
       "novalidate": "true"
     ) do %>
     <%= render "govuk_publishing_components/components/radio", {
@@ -22,8 +21,9 @@
       name: "dietary_requirements",
       description: sanitize(t("coronavirus_form.questions.dietary_requirements.hint")),
       error_message: error_items("dietary_requirements"),
-      items: t("coronavirus_form.questions.dietary_requirements.options").map do |_, item|
+      items: t("coronavirus_form.questions.dietary_requirements.options").map.with_index do |(_, item), index|
         {
+          id: ("dietary_requirements" if index == 0),
           value: item[:label],
           text: item[:label],
           checked: session[:dietary_requirements] == item[:label],

--- a/app/views/coronavirus_form/essential_supplies.html.erb
+++ b/app/views/coronavirus_form/essential_supplies.html.erb
@@ -13,7 +13,6 @@
     <%= form_tag({},
       "data-module": "track-coronavirus-form-vulnerable-people-essential-supplies",
       "data-question-key": "essential_supplies",
-      "id": "essential_supplies",
       "novalidate": "true"
     ) do %>
     <%= render "govuk_publishing_components/components/radio", {
@@ -22,8 +21,9 @@
       name: "essential_supplies",
       description: t("coronavirus_form.questions.essential_supplies.hint"),
       error_message: error_items("essential_supplies"),
-      items: t("coronavirus_form.questions.essential_supplies.options").map do |_, item|
+      items: t("coronavirus_form.questions.essential_supplies.options").map.with_index do |(_, item), index|
         {
+          id: ("essential_supplies" if index == 0),
           value: item[:label],
           text: item[:label],
           checked: session[:essential_supplies] == item[:label],

--- a/app/views/coronavirus_form/know_nhs_number.html.erb
+++ b/app/views/coronavirus_form/know_nhs_number.html.erb
@@ -15,7 +15,6 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulnerable-people-know_nhs_number",
   "data-question-key": "know_nhs_number",
-  "id": "know_nhs_number",
   "novalidate": "true"
 ) do %>
 
@@ -25,8 +24,9 @@
       name: "know_nhs_number",
       error_message: error_items("know_nhs_number"),
       hint: sanitize(t("coronavirus_form.questions.know_nhs_number.hint")),
-      items: t("coronavirus_form.questions.know_nhs_number.options").map do |_, item|
+      items: t("coronavirus_form.questions.know_nhs_number.options").map.with_index do |(_, item), index|
         {
+          id: ("know_nhs_number" if index == 0),
           value: item[:label],
           text: item[:label],
           checked: session[:know_nhs_number] == item[:label],

--- a/app/views/coronavirus_form/live_in_england.html.erb
+++ b/app/views/coronavirus_form/live_in_england.html.erb
@@ -10,7 +10,6 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulnerable-people-live_in_england",
   "data-question-key": "live_in_england",
-  "id": "live_in_england",
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
@@ -18,8 +17,9 @@
   is_page_heading: true,
   name: "live_in_england",
   error_message: error_items('live_in_england'),
-  items: t('coronavirus_form.questions.live_in_england.options').map do |_, item|
+  items: t('coronavirus_form.questions.live_in_england.options').map.with_index do |(_, item), index|
     {
+      id: ("live_in_england" if index == 0),
       value: item[:label],
       text: item[:label],
       checked: session[:live_in_england] == item[:label],

--- a/app/views/coronavirus_form/medical_conditions.html.erb
+++ b/app/views/coronavirus_form/medical_conditions.html.erb
@@ -17,7 +17,6 @@
     <%= form_tag({},
       "data-module": "track-coronavirus-form-vulnerable-people-medical_conditions",
       "data-question-key": "medical_conditions",
-      "id": "medical_conditions",
       "novalidate": "true"
     ) do %>
     <%= render "govuk_publishing_components/components/radio", {
@@ -26,8 +25,9 @@
       name: "medical_conditions",
       error_message: error_items('medical_conditions'),
       description: description_html,
-      items: t('coronavirus_form.questions.medical_conditions.options').map do |_, item|
+      items: t('coronavirus_form.questions.medical_conditions.options').map.with_index do |(_, item), index|
         {
+          id: ("medical_conditions" if index == 0),
           value: item[:label],
           text: item[:label],
           checked: session[:medical_conditions] == item[:label],
@@ -36,4 +36,3 @@
     } %>
     <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
     <% end %>
-

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -18,7 +18,6 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulnerable-people-name",
   "data-question-key": "name",
-  "id": "name",
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/input", {

--- a/app/views/coronavirus_form/nhs_letter.html.erb
+++ b/app/views/coronavirus_form/nhs_letter.html.erb
@@ -13,7 +13,6 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulnerable-people-nhs_letter",
   "data-question-key": "nhs_letter",
-  "id": "nhs_letter",
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
@@ -21,8 +20,9 @@
   is_page_heading: true,
   name: "nhs_letter",
   error_message: error_items("nhs_letter"),
-  items: t("coronavirus_form.questions.nhs_letter.options").map do |_, item|
+  items: t("coronavirus_form.questions.nhs_letter.options").map.with_index do |(_, item), index|
     {
+      id: ("nhs_letter" if index == 0),
       value: item[:label],
       text: item[:label],
       checked: session[:nhs_letter] == item[:label],

--- a/app/views/coronavirus_form/nhs_number.html.erb
+++ b/app/views/coronavirus_form/nhs_number.html.erb
@@ -12,7 +12,6 @@
     <%= form_tag({},
       "data-module": "track-coronavirus-form-vulnerable-people-nhs-number",
       "data-question-key": "nhs_number",
-      "id": "nhs_number",
       "novalidate": "true"
     ) do %>
 
@@ -30,6 +29,7 @@
     } %>
 
     <%= render "govuk_publishing_components/components/input", {
+      "id": "nhs_number",
       name: "nhs_number",
       label: {
         text: t('coronavirus_form.questions.nhs_number.nhs_number.label'),

--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -22,7 +22,6 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulernable-people-support-address",
   "data-question-key": "support_address",
-  "id": "support_address",
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/input", {
@@ -86,5 +85,5 @@
   autocomplete: "postal-code",
 } %>
 
-<%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>


### PR DESCRIPTION
The id was previously on the form tag itself, it needs to be on the
first input instead.

A few inputs such as the email and nhs number field needed hooking up
too.

This important to make sure the error summary works well with screen readers.

To test this change, run the application locally and check each validation message focuses (yellow outline) the right input.

Closes https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/issues/132