### PR TITLE
Increase static asset cache time from 1d to 1y

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   if ENV["RAILS_SERVE_STATIC_FILES"].present?
     config.public_file_server.enabled = true
     config.public_file_server.headers = {
-      "Cache-Control" => "public, s-maxage=86400, max-age=86400",
+      "Cache-Control" => "public, s-maxage=31536000, max-age=31536000",
       "Expires" => 1.day.from_now.to_formatted_s(:rfc822),
     }
   else


### PR DESCRIPTION
As mentioned in #136, both [web.dev](https://web.dev/uses-long-cache-ttl/#how-to-cache-static-resources-using-http-caching) and [Web Fundamentals](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#invalidating_and_updating_cached_responses) recommend 1 year for static assets.

Assets with a cache set to this length will be invalidated by the unique fingerprint added to the filename should they be changed.