### PR TITLE
Remove redundant Expires header

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,6 @@ Rails.application.configure do
     config.public_file_server.enabled = true
     config.public_file_server.headers = {
       "Cache-Control" => "public, s-maxage=31536000, max-age=31536000",
-      "Expires" => 1.day.from_now.to_formatted_s(:rfc822),
     }
   else
     config.public_file_server.enabled = false


### PR DESCRIPTION
In @Nooshu's PR #137 we increase the Cache-Control max age from 1 day to
1 year, but I think we missed the Expires header, which we're also
setting.

I'm not sure how browsers would handle this, but I'm confident the
answer will be "not what we want".

According to https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#cache-control
we can just remove it:

> Note: The Cache-Control header was defined as part of the HTTP/1.1
specification and supersedes previous headers (for example, Expires)
used to define response caching policies. All modern browsers support
Cache-Control, so that's all you need.