### PR TITLE
Fix contact replay on invalid input

### DIFF
--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -10,13 +10,13 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
 
   def submit
     contact_details = {
-      phone_number_calls: sanitize(params[:phone_number_calls]).presence,
-      phone_number_texts: sanitize(params[:phone_number_texts]).presence,
-      email: sanitize(params[:email]).presence,
+      "phone_number_calls" => sanitize(params[:phone_number_calls]).presence,
+      "phone_number_texts" => sanitize(params[:phone_number_texts]).presence,
+      "email" => sanitize(params[:email]).presence,
     }
     session[:contact_details] = contact_details
 
-    invalid_fields = contact_details[:email] ? validate_email_address("email", contact_details[:email]) : []
+    invalid_fields = contact_details["email"] ? validate_email_address("email", contact_details["email"]) : []
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -32,6 +32,7 @@
     text: t("coronavirus_form.questions.contact_details.phone_number_calls.label"),
   },
   value: session.dig("contact_details", "phone_number_calls"),
+  error_message: error_items("phone_number_calls"),
   width: 20,
   type: "tel",
   autocomplete: "tel",
@@ -43,6 +44,7 @@
     text: t("coronavirus_form.questions.contact_details.phone_number_texts.label"),
   },
   value: session.dig("contact_details", "phone_number_texts"),
+  error_message: error_items("phone_number_texts"),
   width: 20,
   type: "tel",
   autocomplete: "tel",
@@ -54,6 +56,7 @@
     text: t("coronavirus_form.questions.contact_details.email.label"),
   },
   value: session.dig("contact_details", "email"),
+  error_message: error_items("email"),
   type: "email",
   autocomplete: "email",
 } %>

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
   describe "POST submit" do
     let(:params) do
       {
-        phone_number_calls: "1234",
-        phone_number_texts: "5678",
-        email: "somewhere@somewhere.com",
+        "phone_number_calls" => "1234",
+        "phone_number_texts" => "5678",
+        "email" => "somewhere@somewhere.com",
       }
     end
 


### PR DESCRIPTION
We were using symbols as hash keys, but the view was expecting a string.  This stopped the user input being shown when an error was displayed.

Changing to a string to be consistent to be consistent with all other controllers.

Also updated the display of error messages, so they appear alongside the fields, as in other views.

Trello card: https://trello.com/c/PC4pgdYB