### PR TITLE
Align question spacing across pages

### DIFF
--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -19,6 +19,7 @@
 <%= render "govuk_publishing_components/components/title", {
   title: t("coronavirus_form.questions.contact_details.title"),
   margin_top: 0,
+  margin_bottom: 3,
 } %>
 
 <%= render "govuk_publishing_components/components/hint", {

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -17,6 +17,7 @@
 <%= render "govuk_publishing_components/components/title", {
   title: t("coronavirus_form.questions.date_of_birth.title"),
   margin_top: 0,
+  margin_bottom: 3,
 } %>
 
 <%= render "govuk_publishing_components/components/date_input", {

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -18,7 +18,8 @@
 
   <%= render "govuk_publishing_components/components/title", {
   title: t("coronavirus_form.questions.name.title"),
-  margin_top: 0
+  margin_top: 0,
+  margin_bottom: 3,
 } %>
 
 <%= render "govuk_publishing_components/components/hint", {

--- a/app/views/coronavirus_form/nhs_number.html.erb
+++ b/app/views/coronavirus_form/nhs_number.html.erb
@@ -18,6 +18,7 @@
     <%= render "govuk_publishing_components/components/title", {
       title: t('coronavirus_form.questions.nhs_number.title'),
       margin_top: 0,
+      margin_bottom: 3,
     } %>
 
     <%= render "govuk_publishing_components/components/hint", {

--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -12,7 +12,8 @@
 
 <%= render "govuk_publishing_components/components/title", {
   title: t("coronavirus_form.questions.support_address.title"),
-  margin_top: 0
+  margin_top: 0,
+  margin_bottom: 3,
 } %>
 
 <%= render "govuk_publishing_components/components/hint", {


### PR DESCRIPTION
Align title/question spacing across pages.

Radios have a spacing of 3 units after the title/question. This brings all the other question pages in line with them.

Follow up on https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/143#issuecomment-602461862