### PR TITLE
Correctly replay NHS number

### DIFF
--- a/app/views/coronavirus_form/nhs_number.html.erb
+++ b/app/views/coronavirus_form/nhs_number.html.erb
@@ -36,7 +36,7 @@
       },
       type: "number",
       error_message: error_items('nhs_number'),
-      value: session.dig("nhs_number"),
+      value: session[:nhs_number],
       width: 20,
     } %>
 


### PR DESCRIPTION
This is being stored in the session hash using a symbol key, however we are attempting to replay it using a string key.  This does not always work in all cases.