### PR TITLE
Strings to symbols

### DIFF
--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -17,7 +17,7 @@ class CoronavirusForm::BasicCareNeedsController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to dietary_requirements_url

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -13,7 +13,7 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
                        validate_email_address("email", session[:contact_details].dig(:email))
                      else
                        []
-      end
+                     end
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -9,7 +9,11 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
     }
     session[:contact_details] = contact_details
 
-    invalid_fields = contact_details[:email] ? validate_email_address("email", contact_details[:email]) : []
+    invalid_fields = if session[:contact_details].dig(:email)
+        validate_email_address("email", session[:contact_details].dig(:email))
+      else
+        []
+      end
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -3,13 +3,13 @@
 class CoronavirusForm::ContactDetailsController < ApplicationController
   def submit
     contact_details = {
-      "phone_number_calls" => strip_tags(params[:phone_number_calls]&.strip).presence,
-      "phone_number_texts" => strip_tags(params[:phone_number_texts]&.strip).presence,
-      "email" => strip_tags(params[:email]&.strip).presence,
+      phone_number_calls: strip_tags(params[:phone_number_calls]&.strip).presence,
+      phone_number_texts: strip_tags(params[:phone_number_texts]&.strip).presence,
+      email: strip_tags(params[:email]&.strip).presence,
     }
     session[:contact_details] = contact_details
 
-    invalid_fields = contact_details["email"] ? validate_email_address("email", contact_details["email"]) : []
+    invalid_fields = contact_details[:email] ? validate_email_address("email", contact_details[:email]) : []
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -10,9 +10,9 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
     session[:contact_details] = contact_details
 
     invalid_fields = if session[:contact_details].dig(:email)
-        validate_email_address("email", session[:contact_details].dig(:email))
-      else
-        []
+                       validate_email_address("email", session[:contact_details].dig(:email))
+                     else
+                       []
       end
 
     if invalid_fields.any?

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -18,7 +18,7 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to medical_conditions_url

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -8,14 +8,14 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
 
   def submit
     session[:date_of_birth] ||= {}
-    session[:date_of_birth]["day"] = strip_tags(params.dig("date_of_birth", "day")&.strip).presence
-    session[:date_of_birth]["month"] = strip_tags(params.dig("date_of_birth", "month")&.strip).presence
-    session[:date_of_birth]["year"] = strip_tags(params.dig("date_of_birth", "year")&.strip).presence
+    session[:date_of_birth][:day] = strip_tags(params.dig("date_of_birth", "day")&.strip).presence
+    session[:date_of_birth][:month] = strip_tags(params.dig("date_of_birth", "month")&.strip).presence
+    session[:date_of_birth][:year] = strip_tags(params.dig("date_of_birth", "year")&.strip).presence
 
     invalid_fields = validate_date_of_birth(
-      session[:date_of_birth]["year"],
-      session[:date_of_birth]["month"],
-      session[:date_of_birth]["day"],
+      session[:date_of_birth][:year],
+      session[:date_of_birth][:month],
+      session[:date_of_birth][:day],
       "date_of_birth",
     )
 

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -13,9 +13,9 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
     session[:date_of_birth][:year] = strip_tags(params.dig("date_of_birth", "year")&.strip).presence
 
     invalid_fields = validate_date_of_birth(
-      session[:date_of_birth][:year],
-      session[:date_of_birth][:month],
-      session[:date_of_birth][:day],
+      session[:date_of_birth].dig(:year),
+      session[:date_of_birth].dig(:month),
+      session[:date_of_birth].dig(:day),
       "date_of_birth",
     )
 

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -8,9 +8,9 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
 
   def submit
     session[:date_of_birth] ||= {}
-    session[:date_of_birth][:day] = strip_tags(params.dig("date_of_birth", "day")&.strip).presence
-    session[:date_of_birth][:month] = strip_tags(params.dig("date_of_birth", "month")&.strip).presence
-    session[:date_of_birth][:year] = strip_tags(params.dig("date_of_birth", "year")&.strip).presence
+    session[:date_of_birth][:day] = strip_tags(params.dig(:date_of_birth, :day)&.strip).presence
+    session[:date_of_birth][:month] = strip_tags(params.dig(:date_of_birth, :month)&.strip).presence
+    session[:date_of_birth][:year] = strip_tags(params.dig(:date_of_birth, :year)&.strip).presence
 
     invalid_fields = validate_date_of_birth(
       session[:date_of_birth].dig(:year),

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -26,7 +26,7 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to support_address_url

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -2,20 +2,20 @@
 
 class CoronavirusForm::DateOfBirthController < ApplicationController
   def show
-    session["date_of_birth"] ||= {}
+    session[:date_of_birth] ||= {}
     super
   end
 
   def submit
-    session["date_of_birth"] ||= {}
-    session["date_of_birth"]["day"] = strip_tags(params.dig("date_of_birth", "day")&.strip).presence
-    session["date_of_birth"]["month"] = strip_tags(params.dig("date_of_birth", "month")&.strip).presence
-    session["date_of_birth"]["year"] = strip_tags(params.dig("date_of_birth", "year")&.strip).presence
+    session[:date_of_birth] ||= {}
+    session[:date_of_birth]["day"] = strip_tags(params.dig("date_of_birth", "day")&.strip).presence
+    session[:date_of_birth]["month"] = strip_tags(params.dig("date_of_birth", "month")&.strip).presence
+    session[:date_of_birth]["year"] = strip_tags(params.dig("date_of_birth", "year")&.strip).presence
 
     invalid_fields = validate_date_of_birth(
-      session["date_of_birth"]["year"],
-      session["date_of_birth"]["month"],
-      session["date_of_birth"]["day"],
+      session[:date_of_birth]["year"],
+      session[:date_of_birth]["month"],
+      session[:date_of_birth]["day"],
       "date_of_birth",
     )
 

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::DateOfBirthController < ApplicationController
-  def show
-    session[:date_of_birth] ||= {}
-    super
-  end
-
   def submit
     session[:date_of_birth] ||= {}
     session[:date_of_birth][:day] = strip_tags(params.dig(:date_of_birth, :day)&.strip).presence

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -17,7 +17,7 @@ class CoronavirusForm::DietaryRequirementsController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to carry_supplies_url

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -17,7 +17,7 @@ class CoronavirusForm::EssentialSuppliesController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to basic_care_needs_url

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -21,7 +21,7 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
       end
     elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label")
       redirect_to nhs_number_url
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
       redirect_to essential_supplies_url

--- a/app/controllers/coronavirus_form/live_in_england_controller.rb
+++ b/app/controllers/coronavirus_form/live_in_england_controller.rb
@@ -21,7 +21,7 @@ class CoronavirusForm::LiveInEnglandController < ApplicationController
       end
     elsif session[:live_in_england] == I18n.t("coronavirus_form.questions.live_in_england.options.option_no.label")
       redirect_to not_eligible_england_url
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to nhs_letter_url

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::MedicalConditionsController < ApplicationController
       end
     elsif session[:medical_conditions] == I18n.t("coronavirus_form.questions.medical_conditions.options.option_no.label")
       redirect_to not_eligible_medical_url
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to know_nhs_number_url

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -8,9 +8,9 @@ class CoronavirusForm::NameController < ApplicationController
 
   def submit
     session[:name] ||= {}
-    session[:name]["first_name"] = strip_tags(params[:first_name]&.strip).presence
-    session[:name]["middle_name"] = strip_tags(params[:middle_name]&.strip).presence
-    session[:name]["last_name"] = strip_tags(params[:last_name]&.strip).presence
+    session[:name][:first_name] = strip_tags(params[:first_name]&.strip).presence
+    session[:name][:middle_name] = strip_tags(params[:middle_name]&.strip).presence
+    session[:name][:last_name] = strip_tags(params[:last_name]&.strip).presence
 
     invalid_fields = validate_text_fields(%w[first_name last_name], controller_name)
 
@@ -32,7 +32,7 @@ private
 
   def validate_text_fields(mandatory_fields, page)
     mandatory_fields.each_with_object([]) do |field, invalid_fields|
-      next if session[:name][field].present?
+      next if session[:name][field.to_sym].present?
 
       invalid_fields << { field: field.to_s,
                           text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -21,7 +21,7 @@ class CoronavirusForm::NameController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to date_of_birth_url

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -12,7 +12,7 @@ class CoronavirusForm::NameController < ApplicationController
     session[:name][:middle_name] = strip_tags(params[:middle_name]&.strip).presence
     session[:name][:last_name] = strip_tags(params[:last_name]&.strip).presence
 
-    invalid_fields = validate_text_fields(%w[first_name last_name], controller_name)
+    invalid_fields = validate_text_fields(%i[first_name last_name], controller_name)
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
@@ -32,7 +32,7 @@ private
 
   def validate_text_fields(mandatory_fields, page)
     mandatory_fields.each_with_object([]) do |field, invalid_fields|
-      next if session[:name][field.to_sym].present?
+      next if session[:name].dig(field).present?
 
       invalid_fields << { field: field.to_s,
                           text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::NameController < ApplicationController
-  def show
-    session[:name] ||= {}
-    super
-  end
-
   def submit
     session[:name] ||= {}
     session[:name][:first_name] = strip_tags(params[:first_name]&.strip).presence

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -2,17 +2,17 @@
 
 class CoronavirusForm::NameController < ApplicationController
   def show
-    session["name"] ||= {}
+    session[:name] ||= {}
     super
   end
 
   def submit
-    session["name"] ||= {}
-    session["name"]["first_name"] = strip_tags(params[:first_name]&.strip).presence
-    session["name"]["middle_name"] = strip_tags(params[:middle_name]&.strip).presence
-    session["name"]["last_name"] = strip_tags(params[:last_name]&.strip).presence
+    session[:name] ||= {}
+    session[:name]["first_name"] = strip_tags(params[:first_name]&.strip).presence
+    session[:name]["middle_name"] = strip_tags(params[:middle_name]&.strip).presence
+    session[:name]["last_name"] = strip_tags(params[:last_name]&.strip).presence
 
-    invalid_fields = validate_text_fields(%w[first_name last_name], "name")
+    invalid_fields = validate_text_fields(%w[first_name last_name], controller_name)
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
@@ -32,7 +32,7 @@ private
 
   def validate_text_fields(mandatory_fields, page)
     mandatory_fields.each_with_object([]) do |field, invalid_fields|
-      next if session["name"][field].present?
+      next if session[:name][field].present?
 
       invalid_fields << { field: field.to_s,
                           text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -17,7 +17,7 @@ class CoronavirusForm::NhsLetterController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to name_url

--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -5,7 +5,7 @@ class CoronavirusForm::NhsNumberController < ApplicationController
 
   def submit
     session[:nhs_number] ||= ""
-    session[:nhs_number] = strip_tags(clean_nhs_number(params["nhs_number"])).presence
+    session[:nhs_number] = strip_tags(clean_nhs_number(params[:nhs_number])).presence
 
     invalid_fields = validate_fields(session[:nhs_number])
 

--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -16,7 +16,7 @@ class CoronavirusForm::NhsNumberController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to essential_supplies_url

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::SupportAddressController < ApplicationController
-  REQUIRED_FIELDS = %w(
+
+  REQUIRED_FIELDS = %i[
       building_and_street_line_1
       town_city
-  ).freeze
+  ].freeze
 
   def show
     session[:support_address] ||= {}
@@ -41,21 +42,21 @@ private
     [
       validate_missing_fields(support_address),
       validate_conditionally_present_fields(support_address),
-      validate_postcode("postcode", support_address[:postcode]),
+      validate_postcode("postcode", support_address.dig(:postcode),
     ].flatten.uniq
   end
 
   def validate_conditionally_present_fields(product)
-    return [] if product[:postcode].present? || product[:county].present?
+    return [] if product.dig(:postcode).present? || product.dig(:county).present?
 
     invalid_fields = []
 
-    if product[:county].blank?
+    if product.dig(:county).blank?
       invalid_fields << {
         field: "county",
         text: t("coronavirus_form.errors.missing_county_or_postcode_field"),
       }
-    elsif product[:postcode].blank?
+    elsif product.dig(:postcode).blank?
       invalid_fields << {
         field: "postcode",
         text: t("coronavirus_form.errors.missing_county_or_postcode_field"),
@@ -67,7 +68,7 @@ private
 
   def validate_missing_fields(product)
     REQUIRED_FIELDS.each_with_object([]) do |field, invalid_fields|
-      next if product[field.to_sym].present?
+      next if product.dig(field).present?
 
       invalid_fields << {
         field: field.to_s,

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -42,7 +42,7 @@ private
     [
       validate_missing_fields(support_address),
       validate_conditionally_present_fields(support_address),
-      validate_postcode("postcode", support_address.dig(:postcode),
+      validate_postcode("postcode", support_address.dig(:postcode)),
     ].flatten.uniq
   end
 

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::SupportAddressController < ApplicationController
-
   REQUIRED_FIELDS = %i[
       building_and_street_line_1
       town_city

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -28,7 +28,7 @@ class CoronavirusForm::SupportAddressController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session["check_answers_seen"]
+    elsif session[:check_answers_seen]
       redirect_to check_your_answers_url
     else
       redirect_to contact_details_url

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -13,11 +13,11 @@ class CoronavirusForm::SupportAddressController < ApplicationController
 
   def submit
     session[:support_address] ||= {}
-    session[:support_address]["building_and_street_line_1"] = strip_tags(params[:building_and_street_line_1]&.strip).presence
-    session[:support_address]["building_and_street_line_2"] = strip_tags(params[:building_and_street_line_2]&.strip).presence
-    session[:support_address]["town_city"] = strip_tags(params[:town_city]&.strip).presence
-    session[:support_address]["county"] = strip_tags(params[:county]&.strip).presence
-    session[:support_address]["postcode"] = strip_tags(params[:postcode]&.strip).presence
+    session[:support_address][:building_and_street_line_1] = strip_tags(params[:building_and_street_line_1]&.strip).presence
+    session[:support_address][:building_and_street_line_2] = strip_tags(params[:building_and_street_line_2]&.strip).presence
+    session[:support_address][:town_city] = strip_tags(params[:town_city]&.strip).presence
+    session[:support_address][:county] = strip_tags(params[:county]&.strip).presence
+    session[:support_address][:postcode] = strip_tags(params[:postcode]&.strip).presence
 
     invalid_fields = validate_fields(session[:support_address])
 
@@ -41,21 +41,21 @@ private
     [
       validate_missing_fields(support_address),
       validate_conditionally_present_fields(support_address),
-      validate_postcode("postcode", support_address["postcode"]),
+      validate_postcode("postcode", support_address[:postcode]),
     ].flatten.uniq
   end
 
   def validate_conditionally_present_fields(product)
-    return [] if product["postcode"].present? || product["county"].present?
+    return [] if product[:postcode].present? || product[:county].present?
 
     invalid_fields = []
 
-    if product["county"].blank?
+    if product[:county].blank?
       invalid_fields << {
         field: "county",
         text: t("coronavirus_form.errors.missing_county_or_postcode_field"),
       }
-    elsif product["postcode"].blank?
+    elsif product[:postcode].blank?
       invalid_fields << {
         field: "postcode",
         text: t("coronavirus_form.errors.missing_county_or_postcode_field"),
@@ -67,7 +67,7 @@ private
 
   def validate_missing_fields(product)
     REQUIRED_FIELDS.each_with_object([]) do |field, invalid_fields|
-      next if product[field].present?
+      next if product[field.to_sym].present?
 
       invalid_fields << {
         field: field.to_s,

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -6,11 +6,6 @@ class CoronavirusForm::SupportAddressController < ApplicationController
       town_city
   ].freeze
 
-  def show
-    session[:support_address] ||= {}
-    super
-  end
-
   def submit
     session[:support_address] ||= {}
     session[:support_address][:building_and_street_line_1] = strip_tags(params[:building_and_street_line_1]&.strip).presence

--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -26,14 +26,14 @@ module AnswersHelper
 
     if question.eql?("contact_details")
       concatenated_answer = []
-      concatenated_answer << "Phone number: #{answer['phone_number_calls']}" if answer["phone_number_calls"]
-      concatenated_answer << "Text: #{answer['phone_number_texts']}" if answer["phone_number_texts"]
-      concatenated_answer << "Email: #{answer['email']}" if answer["email"]
+      concatenated_answer << "Phone number: #{answer[:phone_number_calls]}" if answer[:phone_number_calls]
+      concatenated_answer << "Text: #{answer[:phone_number_texts]}" if answer[:phone_number_texts]
+      concatenated_answer << "Email: #{answer[:email]}" if answer[:email]
       concatenated_answer.join("<br>")
     elsif question.eql?("support_address")
       answer.values.compact.join(",<br>")
     elsif question.eql?("date_of_birth")
-      Time.zone.local(answer["year"], answer["month"], answer["day"]).strftime("%d/%m/%-Y") if complete_date?(answer)
+      Time.zone.local(answer[:year], answer[:month], answer[:day]).strftime("%d/%m/%-Y") if complete_date?(answer)
     else
       answer.values.compact.join(" ")
     end
@@ -41,7 +41,7 @@ module AnswersHelper
 
   def complete_date?(date)
     date.present? &&
-      %w(day month year).all? { |required_key| date.key?(required_key) } &&
+      %i(day month year).all? { |required_key| date.key?(required_key) } &&
       date.values.all?(&:present?)
   end
 

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -31,7 +31,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_calls.label"),
   },
-  value: session.dig("contact_details", "phone_number_calls"),
+  value: session[:contact_details]["phone_number_calls"],
   error_message: error_items("phone_number_calls"),
   width: 20,
   type: "tel",
@@ -43,7 +43,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_texts.label"),
   },
-  value: session.dig("contact_details", "phone_number_texts"),
+  value: session[:contact_details]["phone_number_texts"],
   error_message: error_items("phone_number_texts"),
   width: 20,
   type: "tel",
@@ -56,7 +56,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.email.label"),
   },
-  value: session.dig("contact_details", "email"),
+  value: session[:contact_details]["email"],
   error_message: error_items("email"),
   type: "email",
   autocomplete: "email",

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -31,7 +31,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_calls.label"),
   },
-  value: session[:contact_details]["phone_number_calls"],
+  value: session[:contact_details][:phone_number_calls],
   error_message: error_items("phone_number_calls"),
   width: 20,
   type: "tel",
@@ -43,7 +43,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_texts.label"),
   },
-  value: session[:contact_details]["phone_number_texts"],
+  value: session[:contact_details][:phone_number_texts],
   error_message: error_items("phone_number_texts"),
   width: 20,
   type: "tel",
@@ -56,7 +56,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.email.label"),
   },
-  value: session[:contact_details]["email"],
+  value: session[:contact_details][:email],
   error_message: error_items("email"),
   type: "email",
   autocomplete: "email",

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -31,7 +31,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_calls.label"),
   },
-  value: session[:contact_details][:phone_number_calls],
+  value: session.dig(:contact_details, :phone_number_calls),
   error_message: error_items("phone_number_calls"),
   width: 20,
   type: "tel",
@@ -43,7 +43,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_texts.label"),
   },
-  value: session[:contact_details][:phone_number_texts],
+  value: session.dig(:contact_details, :phone_number_texts),
   error_message: error_items("phone_number_texts"),
   width: 20,
   type: "tel",
@@ -56,7 +56,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.email.label"),
   },
-  value: session[:contact_details][:email],
+  value: session.dig(:contact_details, :email),
   error_message: error_items("email"),
   type: "email",
   autocomplete: "email",

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -30,7 +30,7 @@
       id: "date_of_birth-day",
       name: "day",
       width: 2,
-      value: session["date_of_birth"]["day"],
+      value: session[:date_of_birth]["day"],
       autocomplete: "bday-day",
     },
     {
@@ -38,7 +38,7 @@
       id: "date_of_birth-month",
       name: "month",
       width: 2,
-      value: session["date_of_birth"]["month"],
+      value: session[:date_of_birth]["month"],
       autocomplete: "bday-month",
     },
     {
@@ -46,7 +46,7 @@
       id: "date_of_birth-year",
       name: "year",
       width: 4,
-      value: session["date_of_birth"]["year"],
+      value: session[:date_of_birth]["year"],
       autocomplete: "bday-year",
     }
   ]

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -30,7 +30,7 @@
       id: "date_of_birth-day",
       name: "day",
       width: 2,
-      value: session[:date_of_birth]["day"],
+      value: session[:date_of_birth][:day],
       autocomplete: "bday-day",
     },
     {
@@ -38,7 +38,7 @@
       id: "date_of_birth-month",
       name: "month",
       width: 2,
-      value: session[:date_of_birth]["month"],
+      value: session[:date_of_birth][:month],
       autocomplete: "bday-month",
     },
     {
@@ -46,7 +46,7 @@
       id: "date_of_birth-year",
       name: "year",
       width: 4,
-      value: session[:date_of_birth]["year"],
+      value: session[:date_of_birth][:year],
       autocomplete: "bday-year",
     }
   ]

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -30,7 +30,7 @@
       id: "date_of_birth-day",
       name: "day",
       width: 2,
-      value: session[:date_of_birth][:day],
+      value: session.dig(:date_of_birth, :day),
       autocomplete: "bday-day",
     },
     {
@@ -38,7 +38,7 @@
       id: "date_of_birth-month",
       name: "month",
       width: 2,
-      value: session[:date_of_birth][:month],
+      value: session.dig(:date_of_birth, :month),
       autocomplete: "bday-month",
     },
     {
@@ -46,7 +46,7 @@
       id: "date_of_birth-year",
       name: "year",
       width: 4,
-      value: session[:date_of_birth][:year],
+      value: session.dig(:date_of_birth, :year),
       autocomplete: "bday-year",
     }
   ]

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -33,7 +33,7 @@
   id: "first_name",
   name: "first_name",
   error_message: error_items("first_name"),
-  value: session["name"]["first_name"],
+  value: session[:name]["first_name"],
   autocomplete: "given-name",
 } %>
 
@@ -44,7 +44,7 @@
   id: "middle_name",
   name: "middle_name",
   error_message: error_items("middle_name"),
-  value: session["name"]["middle_name"],
+  value: session[:name]["middle_name"],
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -54,7 +54,7 @@
   id: "last_name",
   name: "last_name",
   error_message: error_items("last_name"),
-  value: session["name"]["last_name"],
+  value: session[:name]["last_name"],
   autocomplete: "family-name",
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -33,7 +33,7 @@
   id: "first_name",
   name: "first_name",
   error_message: error_items("first_name"),
-  value: session[:name]["first_name"],
+  value: session[:name][:first_name],
   autocomplete: "given-name",
 } %>
 
@@ -44,7 +44,7 @@
   id: "middle_name",
   name: "middle_name",
   error_message: error_items("middle_name"),
-  value: session[:name]["middle_name"],
+  value: session[:name][:middle_name],
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -54,7 +54,7 @@
   id: "last_name",
   name: "last_name",
   error_message: error_items("last_name"),
-  value: session[:name]["last_name"],
+  value: session[:name][:last_name],
   autocomplete: "family-name",
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -33,7 +33,7 @@
   id: "first_name",
   name: "first_name",
   error_message: error_items("first_name"),
-  value: session[:name][:first_name],
+  value: session.dig(:name, :first_name),
   autocomplete: "given-name",
 } %>
 
@@ -44,7 +44,7 @@
   id: "middle_name",
   name: "middle_name",
   error_message: error_items("middle_name"),
-  value: session[:name][:middle_name],
+  value: session.dig(:name, :middle_name),
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -54,7 +54,7 @@
   id: "last_name",
   name: "last_name",
   error_message: error_items("last_name"),
-  value: session[:name][:last_name],
+  value: session.dig(:name, :last_name),
   autocomplete: "family-name",
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -33,7 +33,7 @@
   name: "building_and_street_line_1",
   type: "text",
   error_message: error_items('building_and_street_line_1'),
-  value: session[:support_address]["building_and_street_line_1"],
+  value: session[:support_address][:building_and_street_line_1],
   autocomplete: "address-line1",
 } %>
 
@@ -44,7 +44,7 @@
   id: "building_and_street_line_2",
   name: "building_and_street_line_2",
   error_message: error_items('building_and_street_line_2'),
-  value: session[:support_address]["building_and_street_line_2"],
+  value: session[:support_address][:building_and_street_line_2],
   autocomplete: "address-line2",
 } %>
 
@@ -56,7 +56,7 @@
   name: "town_city",
   type: "text",
   error_message: error_items('town_city'),
-  value: session[:support_address]["town_city"],
+  value: session[:support_address][:town_city],
   width: 20,
   autocomplete: "address-level2",
 } %>
@@ -69,7 +69,7 @@
   name: "county",
   type: "text",
   error_message: error_items('county'),
-  value: session[:support_address]["county"],
+  value: session[:support_address][:county],
   width: 20,
 } %>
 
@@ -81,7 +81,7 @@
   name: "postcode",
   type: "text",
   error_message: error_items('postcode'),
-  value: session[:support_address]["postcode"],
+  value: session[:support_address][:postcode],
   width: 10,
   autocomplete: "postal-code",
 } %>

--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -33,7 +33,7 @@
   name: "building_and_street_line_1",
   type: "text",
   error_message: error_items('building_and_street_line_1'),
-  value: session[:support_address][:building_and_street_line_1],
+  value: session.dig(:support_address, :building_and_street_line_1),
   autocomplete: "address-line1",
 } %>
 
@@ -44,7 +44,7 @@
   id: "building_and_street_line_2",
   name: "building_and_street_line_2",
   error_message: error_items('building_and_street_line_2'),
-  value: session[:support_address][:building_and_street_line_2],
+  value: session.dig(:support_address, :building_and_street_line_2),
   autocomplete: "address-line2",
 } %>
 
@@ -56,7 +56,7 @@
   name: "town_city",
   type: "text",
   error_message: error_items('town_city'),
-  value: session[:support_address][:town_city],
+  value: session.dig(:support_addres, :town_city),
   width: 20,
   autocomplete: "address-level2",
 } %>
@@ -69,7 +69,7 @@
   name: "county",
   type: "text",
   error_message: error_items('county'),
-  value: session[:support_address][:county],
+  value: session.dig(:support_address, :county),
   width: 20,
 } %>
 
@@ -81,7 +81,7 @@
   name: "postcode",
   type: "text",
   error_message: error_items('postcode'),
-  value: session[:support_address][:postcode],
+  value: session.dig(:support_address, :postcode),
   width: 10,
   autocomplete: "postal-code",
 } %>

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
     end
 
     it "saves the form response to the database" do
-      session["attribute"] = "key"
+      session[:attribute] = "key"
       post :submit
 
       expect(FormResponse.first).to have_attributes(

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       }
     end
 
-    it "sets session variables as sanatized symbolized keys" do
+    it "sets session variables as sanitize symbolized keys" do
       post :submit, params: params
       expect(session[session_key]).to eq contact_details
     end

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -20,15 +20,23 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
   describe "POST submit" do
     let(:params) do
       {
-        "phone_number_calls" => "1234",
+        "phone_number_calls" => "1234<script></script>",
         "phone_number_texts" => "5678",
-        "email" => "somewhere@somewhere.com",
+        "email" => "<script></script>somewhere@somewhere.com",
       }
     end
 
-    it "sets session variables" do
+    let(:contact_details) do
+      {
+        phone_number_calls: "1234",
+        phone_number_texts: "5678",
+        email: "somewhere@somewhere.com",
+      }
+    end
+
+    it "sets session variables as sanatized symbolized keys" do
       post :submit, params: params
-      expect(session[session_key]).to eq params
+      expect(session[session_key]).to eq contact_details
     end
 
     it "strips html characters" do
@@ -53,7 +61,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
     end
 
     it "does not move to next step with an invalid email address" do
-      post :submit, params: { email: "not-a-valid-email" }
+      post :submit, params: { "email": "not-a-valid-email" }
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       }
 
       contact_details = {
-        "phone_number_calls" => "Link",
-        "phone_number_texts" => "Link",
-        "email" => nil,
+        phone_number_calls: "Link",
+        phone_number_texts: "Link",
+        email: nil,
       }
 
       post :submit, params: params

--- a/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
@@ -28,9 +28,17 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
       }
     end
 
-    it "sets session variables" do
+    let(:date_of_birth) do
+      {
+        day: "31",
+        month: "1",
+        year: "1980",
+      }
+    end
+
+    it "sets session variables as symbolized keys" do
       post :submit, params: params
-      expect(session[session_key]).to eq params["date_of_birth"]
+      expect(session[session_key]).to eq date_of_birth
     end
 
     it "redirects to next step for a permitted response" do

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
     end
 
 
-    it "sets session variables as sanatized symbolized keys" do
+    it "sets session variables as sanitize symbolized keys" do
       post :submit, params: params
       expect(session[session_key]).to eq person
     end

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
       }
 
       name = {
-        "first_name" => "Link",
-        "middle_name" => "Link",
-        "last_name" => "Link",
+        first_name: "Link",
+        middle_name: "Link",
+        last_name: "Link",
       }
 
       post :submit, params: params

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -20,21 +20,21 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
   describe "POST submit" do
     let(:params) do
       {
-        "first_name" => "Harry",
-        "middle_name" => "Snape",
-        "last_name" => "Potter",
+        "first_name" => "Harry<script></script>",
+        "middle_name" => "Snape<script></script>",
+        "last_name" => "<script></script>Potter",
       }
     end
     let(:person) do
       {
-        "first_name" => "Harry",
-        "middle_name" => "Snape",
-        "last_name" => "Potter",
+        first_name: "Harry",
+        middle_name: "Snape",
+        last_name: "Potter",
       }
     end
 
 
-    it "sets session variables" do
+    it "sets session variables as sanatized symbolized keys" do
       post :submit, params: params
       expect(session[session_key]).to eq person
     end
@@ -73,7 +73,7 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
     it "validates middle name is not required" do
       post :submit, params: params.except("middle_name")
 
-      expect(session[session_key]).to eq person.merge("middle_name" => nil)
+      expect(session[session_key]).to eq person.merge(middle_name: nil)
       expect(response).to redirect_to(date_of_birth_path)
     end
 

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -53,11 +53,11 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       }
 
       address = {
-        "building_and_street_line_1" => "Link",
-        "building_and_street_line_2" => "Link",
-        "town_city" => "Link",
-        "county" => "Link",
-        "postcode" => nil,
+        building_and_street_line_1: "Link",
+        building_and_street_line_2: "Link",
+        town_city: "Link",
+        county: "Link",
+        postcode: nil,
       }
 
       post :submit, params: params

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -30,15 +30,15 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
     end
     let(:address) do
       {
-        "building_and_street_line_1" => "Ministry of Magic",
-        "building_and_street_line_2" => "1 Horse Guards Road",
-        "town_city" => "London",
-        "county" => "United Kingdom",
-        "postcode" => "SW1A 2HQ",
+        building_and_street_line_1: "Ministry of Magic",
+        building_and_street_line_2: "1 Horse Guards Road",
+        town_city: "London",
+        county: "United Kingdom",
+        postcode: "SW1A 2HQ",
       }
     end
 
-    it "sets session variables" do
+    it "sets session variables as symbolized keys" do
       post :submit, params: params
 
       expect(session[session_key]).to eq address
@@ -67,7 +67,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
     it "does not require address line 2" do
       post :submit, params: params.except("building_and_street_line_2")
 
-      expect(session[session_key]).to eq address.merge("building_and_street_line_2" => nil)
+      expect(session[session_key]).to eq address.merge(building_and_street_line_2: nil)
       expect(response).to redirect_to(next_page)
     end
 
@@ -75,8 +75,8 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       post :submit, params: params.except("building_and_street_line_2", "county")
 
       expect(session[session_key]).to eq address.merge({
-        "building_and_street_line_2" => nil,
-        "county" => nil,
+        building_and_street_line_2: nil,
+        county: nil,
         })
 
       expect(response).to redirect_to(next_page)
@@ -86,8 +86,8 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       post :submit, params: params.except("building_and_street_line_2", "postcode")
 
       expect(session[session_key]).to eq address.merge({
-        "building_and_street_line_2" => nil,
-        "postcode" => nil,
+        building_and_street_line_2: nil,
+        postcode: nil,
         })
 
       expect(response).to redirect_to(next_page)
@@ -112,7 +112,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       ]
 
       valid_postcodes.each do |postcode|
-        params["postcode"] = postcode
+        params[:postcode] = postcode
         post :submit, params: params
 
         expect(response).to redirect_to(next_page)
@@ -120,7 +120,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
     end
 
     it "does not redirect to next step when postcode is invalid" do
-      params["postcode"] = "AAA1 1AA"
+      params[:postcode] = "AAA1 1AA"
       post :submit, params: params
 
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
 
     described_class::REQUIRED_FIELDS.each do |field|
       it "requires that key #{field} be provided" do
-        post :submit, params: params.except(field)
+        post :submit, params: params.except(field.to_s)
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(current_template)
       end

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -127,11 +127,11 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
     end
 
     it "removes extra whitespace from the postcode" do
-      params["postcode"] = "E1 8QS "
+      params[:postcode] = "E1 8QS "
       post :submit, params: params
 
       expect(response).to redirect_to(next_page)
-      expect(session[session_key]["postcode"]).to eq("E1 8QS")
+      expect(session[session_key][:postcode]).to eq("E1 8QS")
     end
 
     described_class::REQUIRED_FIELDS.each do |field|

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "concatenates contact_details with a line break" do
         answer = {
-          "phone_number_calls" => "012101234567",
-          "phone_number_texts" => "0777001234567",
-          "email" => "me@example.com",
+          phone_number_calls: "012101234567",
+          phone_number_texts: "0777001234567",
+          email: "me@example.com",
         }
 
         expected_answer =
-          "Phone number: #{answer['phone_number_calls']}<br>Text: #{answer['phone_number_texts']}<br>Email: #{answer['email']}"
+          "Phone number: #{answer[:phone_number_calls]}<br>Text: #{answer[:phone_number_texts]}<br>Email: #{answer[:email]}"
 
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
@@ -55,10 +55,10 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "only concatenates the fields that have a value" do
         answer = {
-          "email" => "me@example.com",
+          email: "me@example.com",
         }
 
-        expected_answer = "Email: #{answer['email']}"
+        expected_answer = "Email: #{answer[:email]}"
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
     end
@@ -68,11 +68,11 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "concatenates support_address with a comma and a line break" do
         answer = {
-          "building_and_street_line_1" => "The building",
-          "building_and_street_line_2" => "1 High Street",
-          "town_city" => "Town",
-          "county" => "County",
-          "postcode" => "E1 8QS",
+          building_and_street_line_1: "The building",
+          building_and_street_line_2: "1 High Street",
+          town_city: "Town",
+          county: "County",
+          postcode: "E1 8QS",
         }
 
         expected_answer =
@@ -89,9 +89,9 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "only concatenates the fields that have a value" do
         answer = {
-          "building_and_street_line_1" => "The building",
-          "town_city" => "Town",
-          "postcode" => "E1 8QS",
+          building_and_street_line_1: "The building",
+          town_city: "Town",
+          postcode: "E1 8QS",
         }
 
         expected_answer = "The building,<br>Town,<br>E1 8QS"
@@ -104,9 +104,9 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "concatenates date_of_birth as dd/mm/yyyy" do
         answer = {
-          "year" => "1970",
-          "month" => "01",
-          "day" => "31",
+          year: "1970",
+          month: "01",
+          day: "31",
         }
 
         expected_answer = "31/01/1970"
@@ -115,9 +115,9 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "doesn't pad two character years" do
         answer = {
-          "year" => "70",
-          "month" => "01",
-          "day" => "31",
+          year: "70",
+          month: "01",
+          day: "31",
         }
 
         expected_answer = "31/01/70"
@@ -132,8 +132,8 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "returns nothing if part of the date is missing" do
         answer = {
-          "month" => "01",
-          "day" => "31",
+          month: "01",
+          day: "31",
         }
 
         expect(helper.concat_answer(answer, question)).to be_nil
@@ -141,9 +141,9 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "returns nothing if the date is nil" do
         answer = {
-          "month" => nil,
-          "day" => nil,
-          "year" => nil,
+          month: nil,
+          day: nil,
+          year: nil,
         }
 
         expect(helper.concat_answer(answer, question)).to be_nil
@@ -155,9 +155,9 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "concates other hash questions" do
         answer = {
-          "one" => "One",
-          "two" => "Two",
-          "three" => "Three",
+          one: "One",
+          two: "Two",
+          three: "Three",
         }
 
         expected_answer = "One Two Three"


### PR DESCRIPTION
Dependent on: Get :+1: from product before merging!

## What
Tracks down everywhere we'd made a key in the session object a `String`
and changes it to to a symbol

## Why
Switching between symbols and strings was the source of [this bug](https://stackoverflow.com/questions/8189416/why-use-symbols-as-hash-keys-in-ruby), after a [bit of chat on slack ](https://gds.slack.com/archives/C010JE8AMPZ/p1584955486216800?thread_ts=1584954108.200700&cid=C010JE8AMPZ), agreement that we should switch them all over as an after launch thing.

After a bit of reserach turns out symbols have some other benefits:
- [Symbols have access to ruby 2.0 keyword arguments](https://chriszetter.com/blog/2012/11/02/keyword-arguments-in-ruby-2-dot-0/)
- [Symbols are kind of like immutable strings and so are a tad faster](https://web.archive.org/web/20180709094450/http://www.reactive.io/tips/2009/01/11/the-difference-between-ruby-symbols-and-strings)
