### PR TITLE
Compress JavaScript in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,6 +43,9 @@ Rails.application.configure do
   config.sass.style = :compressed
   config.sass.line_comments = false
 
+  # Compress JavaScript
+  config.assets.js_compressor = :uglifier
+
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
Before: 644kb
After: 235kb

Audits reported a 77kb improvement after GZIP compression.

I tested this by enabling it in the development environment, is there a good way to test this change in a proper production environment?