### PR TITLE
Self host favicon

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title><%= t('coronavirus_form.errors.page_title_prefix') if flash[:validation]&.any? %><%= yield :title %> - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" href="https://www.gov.uk/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="/assets/favicon.ico" type="image/x-icon" />
     <meta name="robots" content="noindex nofollow">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
Prevents the need to open a request to another domain.

Closes https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/issues/151

Can someone double check that I have not messed this up, I'm not super hot on the asset pipeline, thanks :)