### PR TITLE
Redirect users to start of journey if they enter mid-way through

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
 
+  before_action :check_first_question, only: [:show]
+
+  def show; end
+
   if ENV["REQUIRE_BASIC_AUTH"]
     http_basic_authenticate_with(
       name: ENV.fetch("BASIC_AUTH_USERNAME"),
@@ -21,5 +25,11 @@ private
 
   def log_validation_error(invalid_fields)
     logger.info "validation error - #{invalid_fields.pluck(:text).to_sentence}"
+  end
+
+  def check_first_question
+    if session[:live_in_england].blank?
+      redirect_to controller: "coronavirus_form/live_in_england", action: "show"
+    end
   end
 end

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -2,13 +2,9 @@
 
 class CoronavirusForm::CheckAnswersController < ApplicationController
   def show
-    if session[:nhs_letter].present?
-      @items = items
-      session[:check_answers_seen] = true
-      render "coronavirus_form/check_answers"
-    else
-      redirect_to controller: "coronavirus_form/live_in_england", action: "show"
-    end
+    @items = items
+    session[:check_answers_seen] = true
+    render "coronavirus_form/check_answers"
   end
 
   def submit

--- a/app/controllers/coronavirus_form/confirmation_controller.rb
+++ b/app/controllers/coronavirus_form/confirmation_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::ConfirmationController < ApplicationController
+  skip_before_action :check_first_question
+
   def show
     render "coronavirus_form/confirmation"
   end

--- a/app/controllers/coronavirus_form/live_in_england_controller.rb
+++ b/app/controllers/coronavirus_form/live_in_england_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::LiveInEnglandController < ApplicationController
+  skip_before_action :check_first_question
+
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/privacy_controller.rb
+++ b/app/controllers/coronavirus_form/privacy_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::PrivacyController < ApplicationController
+  skip_before_action :check_first_question
+
   def show
     render "coronavirus_form/privacy"
   end

--- a/features/form.feature
+++ b/features/form.feature
@@ -11,9 +11,6 @@ Feature: Filling in the form
     And I click the "Continue" button
     Then I will be redirected to the "/nhs-letter" path
 
-  Scenario: Answers "Have you recently had a letter from the NHS about your situation as someone who’s extremely vulnerable to coronavirus?"
-    When I visit the "/nhs-letter" path
-    Then I can see a "Have you recently had a letter from the NHS about your situation as someone who’s extremely vulnerable to coronavirus?" heading
-    And I choose "Not sure"
-    And I click the "Continue" button
-    Then I will be redirected to the "/name" path
+  Scenario: Visits an intermediate question
+      When I visit the "/essential-supplies" path
+      Then I will be redirected to the "/live-in-england" path

--- a/features/step_definitions/live_in_england_steps.rb
+++ b/features/step_definitions/live_in_england_steps.rb
@@ -1,0 +1,8 @@
+When("I visit the live in England page") do
+  visit basic_care_needs_path
+end
+
+Then("I will be redirected to the NHS letter page") do
+  expect(page.status_code).to eq(200)
+  expect(page).to have_current_path(nhs_letter_path)
+end

--- a/features/step_definitions/live_in_england_steps.rb
+++ b/features/step_definitions/live_in_england_steps.rb
@@ -1,5 +1,5 @@
 When("I visit the live in England page") do
-  visit basic_care_needs_path
+  visit live_in_england_path
 end
 
 Then("I will be redirected to the NHS letter page") do

--- a/features/step_definitions/live_in_england_steps.rb
+++ b/features/step_definitions/live_in_england_steps.rb
@@ -1,8 +1,0 @@
-When("I visit the live in England page") do
-  visit live_in_england_path
-end
-
-Then("I will be redirected to the NHS letter page") do
-  expect(page.status_code).to eq(200)
-  expect(page).to have_current_path(nhs_letter_path)
-end

--- a/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::BasicCareNeedsController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/basic_care_needs" }
   let(:session_key) { :basic_care_needs }
 
@@ -11,11 +13,6 @@ RSpec.describe CoronavirusForm::BasicCareNeedsController, type: :controller do
       session[:live_in_england] = "Yes"
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
@@ -8,8 +8,14 @@ RSpec.describe CoronavirusForm::BasicCareNeedsController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/carry_supplies" }
   let(:session_key) { :carry_supplies }
 
@@ -11,11 +13,6 @@ RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
       session[:live_in_england] = "Yes"
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
@@ -8,8 +8,14 @@ RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
-      session["nhs_letter"] = "yes"
+      session[:live_in_england] = "Yes"
 
       get :show
       expect(response).to render_template(current_template)
@@ -15,7 +15,7 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
 
     it "redirects to start if no session data" do
       get :show
-      expect(response).to redirect_to({ controller: "live_in_england", action: "show" })
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/check_answers" }
 
   describe "GET show" do
@@ -11,11 +13,6 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/confirmation_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/confirmation_controller_spec.rb
@@ -7,8 +7,15 @@ RSpec.describe CoronavirusForm::ConfirmationController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/confirmation_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/confirmation_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::ConfirmationController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/confirmation" }
 
   describe "GET show" do
@@ -11,11 +13,6 @@ RSpec.describe CoronavirusForm::ConfirmationController, type: :controller do
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/confirmation_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/confirmation_controller_spec.rb
@@ -3,14 +3,10 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::ConfirmationController, type: :controller do
-  include_examples "redirections"
-
   let(:current_template) { "coronavirus_form/confirmation" }
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
-
       get :show
       expect(response).to render_template(current_template)
     end

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/contact_details" }
   let(:session_key) { :contact_details }
 
@@ -12,11 +14,6 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/date_of_birth" }
   let(:session_key) { "date_of_birth" }
 
@@ -12,11 +14,6 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/dietary_requirements" }
   let(:session_key) { :dietary_requirements }
 
@@ -12,11 +14,6 @@ RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/essential_supplies" }
   let(:session_key) { :essential_supplies }
 
@@ -12,11 +14,6 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/know_nhs_number" }
   let(:session_key) { :know_nhs_number }
 
@@ -12,11 +14,6 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/medical_conditions" }
   let(:session_key) { :medical_conditions }
 
@@ -12,11 +14,6 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::NameController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/name" }
   let(:session_key) { :name }
 
@@ -12,11 +14,6 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/nhs_letter" }
   let(:session_key) { :nhs_letter }
 
@@ -12,11 +14,6 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
@@ -9,8 +9,15 @@ RSpec.describe CoronavirusForm::NhsNumberController, type: :controller do
   let(:valid_nhs_number) { "110 123 0614" }
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::NhsNumberController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/nhs_number" }
   let(:session_key) { :nhs_number }
   # randomly generated from http://danielbayley.uk/nhs-number/
@@ -13,11 +15,6 @@ RSpec.describe CoronavirusForm::NhsNumberController, type: :controller do
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/not_eligible_england_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/not_eligible_england_controller_spec.rb
@@ -7,8 +7,15 @@ RSpec.describe CoronavirusForm::NotEligibleEnglandController, type: :controller 
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/not_eligible_england_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/not_eligible_england_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::NotEligibleEnglandController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/not_eligible_england" }
 
   describe "GET show" do
@@ -11,11 +13,6 @@ RSpec.describe CoronavirusForm::NotEligibleEnglandController, type: :controller 
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/not_eligible_medical_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/not_eligible_medical_controller_spec.rb
@@ -7,8 +7,15 @@ RSpec.describe CoronavirusForm::NotEligibleMedicalController, type: :controller 
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/not_eligible_medical_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/not_eligible_medical_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::NotEligibleMedicalController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/not_eligible_medical" }
 
   describe "GET show" do
@@ -11,11 +13,6 @@ RSpec.describe CoronavirusForm::NotEligibleMedicalController, type: :controller 
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/privacy_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/privacy_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::PrivacyController, type: :controller do
+  let(:current_template) { "coronavirus_form/privacy" }
+
+  describe "GET show" do
+    it "renders the page" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
+  include_examples "redirections"
+
   let(:current_template) { "coronavirus_form/support_address" }
   let(:session_key) { :support_address }
   let(:next_page) { contact_details_path }
@@ -13,11 +15,6 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
 
       get :show
       expect(response).to render_template(current_template)
-    end
-
-    it "redirects to start if no session data" do
-      get :show
-      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -9,8 +9,15 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
+      session[:live_in_england] = "Yes"
+
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to start if no session data" do
+      get :show
+      expect(response).to redirect_to(live_in_england_path)
     end
   end
 

--- a/spec/support/shared_examples_for_controllers.rb
+++ b/spec/support/shared_examples_for_controllers.rb
@@ -1,0 +1,6 @@
+RSpec.shared_examples "redirections" do
+  it "redirects to start if no session data" do
+    get :show
+    expect(response).to redirect_to(live_in_england_path)
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/bmI1RJhe

# What's changed?
Adds a `before_action` to each controller to check that the user has at the least completed the first question.

The exemptions to this are the first question itself, and the privacy page, because users should be able to ready the privacy policy before proceeding.

# Why?
If a user comes in part way through, e.g. https://coronavirus-vulnerable-people.service.gov.uk/nhs-number, they answer that question then get redirected to the first question only at the "check your answers" page. We should redirect them to the first question earlier on so that they don't have to repeat part of their journey.