### PR TITLE
Strip leading and trailing spaces from text fields

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include ActionView::Helpers::SanitizeHelper
+  include FieldValidationHelper
+
   if ENV["REQUIRE_BASIC_AUTH"]
     http_basic_authenticate_with(
       name: ENV.fetch("BASIC_AUTH_USERNAME"),

--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::BasicCareNeedsController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/carry_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/carry_supplies_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::CarrySuppliesController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::CheckAnswersController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-
   def show
     if session[:nhs_letter].present?
       @items = items

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::ContactDetailsController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -7,9 +7,9 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
 
   def submit
     contact_details = {
-      "phone_number_calls" => sanitize(params[:phone_number_calls]).presence,
-      "phone_number_texts" => sanitize(params[:phone_number_texts]).presence,
-      "email" => sanitize(params[:email]).presence,
+      "phone_number_calls" => sanitize(params[:phone_number_calls]&.strip).presence,
+      "phone_number_texts" => sanitize(params[:phone_number_texts]&.strip).presence,
+      "email" => sanitize(params[:email]&.strip).presence,
     }
     session[:contact_details] = contact_details
 

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -8,9 +8,9 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
 
   def submit
     session["date_of_birth"] ||= {}
-    session["date_of_birth"]["day"] = sanitize(params.dig("date_of_birth", "day")).presence
-    session["date_of_birth"]["month"] = sanitize(params.dig("date_of_birth", "month")).presence
-    session["date_of_birth"]["year"] = sanitize(params.dig("date_of_birth", "year")).presence
+    session["date_of_birth"]["day"] = sanitize(params.dig("date_of_birth", "day")&.strip).presence
+    session["date_of_birth"]["month"] = sanitize(params.dig("date_of_birth", "month")&.strip).presence
+    session["date_of_birth"]["year"] = sanitize(params.dig("date_of_birth", "year")&.strip).presence
 
     invalid_fields = validate_date_of_birth(
       session["date_of_birth"]["year"],

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::DateOfBirthController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     session["date_of_birth"] ||= {}
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::DietaryRequirementsController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::EssentialSuppliesController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::KnowNhsNumberController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/live_in_england_controller.rb
+++ b/app/controllers/coronavirus_form/live_in_england_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::LiveInEnglandController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::MedicalConditionsController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -8,9 +8,9 @@ class CoronavirusForm::NameController < ApplicationController
 
   def submit
     session["name"] ||= {}
-    session["name"]["first_name"] = sanitize(params[:first_name]).presence
-    session["name"]["middle_name"] = sanitize(params[:middle_name]).presence
-    session["name"]["last_name"] = sanitize(params[:last_name]).presence
+    session["name"]["first_name"] = sanitize(params[:first_name]&.strip).presence
+    session["name"]["middle_name"] = sanitize(params[:middle_name]&.strip).presence
+    session["name"]["last_name"] = sanitize(params[:last_name]&.strip).presence
 
     invalid_fields = validate_text_fields(%w[first_name last_name], "name")
 

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::NameController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     session["name"] ||= {}
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::NhsLetterController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   def show
     render "coronavirus_form/#{PAGE}"
   end

--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::NhsNumberController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
   include NhsNumberValidatorHelper
-  include FieldValidationHelper
 
   def show
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -13,11 +13,11 @@ class CoronavirusForm::SupportAddressController < ApplicationController
 
   def submit
     session[:support_address] ||= {}
-    session[:support_address]["building_and_street_line_1"] = sanitize(params[:building_and_street_line_1]).presence
-    session[:support_address]["building_and_street_line_2"] = sanitize(params[:building_and_street_line_2]).presence
-    session[:support_address]["town_city"] = sanitize(params[:town_city]).presence
-    session[:support_address]["county"] = sanitize(params[:county]).presence
-    session[:support_address]["postcode"] = sanitize(params[:postcode]).presence
+    session[:support_address]["building_and_street_line_1"] = sanitize(params[:building_and_street_line_1]&.strip).presence
+    session[:support_address]["building_and_street_line_2"] = sanitize(params[:building_and_street_line_2]&.strip).presence
+    session[:support_address]["town_city"] = sanitize(params[:town_city]&.strip).presence
+    session[:support_address]["county"] = sanitize(params[:county]&.strip).presence
+    session[:support_address]["postcode"] = sanitize(params[:postcode]&.strip).presence
 
     invalid_fields = validate_fields(session[:support_address])
 

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::SupportAddressController < ApplicationController
-  include ActionView::Helpers::SanitizeHelper
-  include FieldValidationHelper
-
   REQUIRED_FIELDS = %w(
       building_and_street_line_1
       town_city

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       expect(response).to render_template(current_template)
     end
 
+    it "removes extra whitespace from the postcode" do
+      params["postcode"] = "E1 8QS "
+      post :submit, params: params
+
+      expect(response).to redirect_to(next_page)
+      expect(session[session_key]["postcode"]).to eq("E1 8QS")
+    end
+
     described_class::REQUIRED_FIELDS.each do |field|
       it "requires that key #{field} be provided" do
         post :submit, params: params.except(field)


### PR DESCRIPTION
Trello: https://trello.com/c/mAHsb30l

# Motivation
Sometimes leading and trailing spaces are added by autocompletes - which causes them to fail validation. The most common occurrence of this is on postcode fields.

See: https://twitter.com/puncakka1/status/1242391848150355969