### PR TITLE
Make it clearer to users that they still need to submit the application

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
     label: Privacy
   check_your_answers:
     title: Are you ready to send your application?
-    hint: Check your answers first
+    hint: Check your answers first.
     heading: Now send your application
     confirmation: By submitting this application you’re confirming that, as far as you know, the details you’re providing are correct.
     submit: Accept and send

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,9 +2,10 @@ en:
   privacy_notice:
     label: Privacy
   check_your_answers:
-    title: Check your answers before sending your application
+    title: Are you ready to send your application?
+    hint: Check your answers first
     heading: Now send your application
-    confirmation: By submitting this application you’re confirming that, to the best of your knowledge, the details you’re providing are correct.
+    confirmation: By submitting this application you’re confirming that, as far as you know, the details you’re providing are correct.
     submit: Accept and send
   not_eligible_medical:
     title: Sorry, you’re not eligible for help through this service


### PR DESCRIPTION
Drop-out rates on this page are about 50% right now. We'd like to try adjusting the content on the page and see if that has any significant effect. We will need to know when this change has gone live, so we can accurately measure the effect on completion rates.