### PR TITLE
Make it clearer to users that they still need to submit the application

### DIFF
--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -11,6 +11,10 @@
   margin_top: 0,
 } %>
 
+<%= render "govuk_publishing_components/components/hint", {
+  text: t('check_your_answers.hint'),
+} %>
+
 <%= render "govuk_publishing_components/components/summary_list", {
   items: @items,
 } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
     label: Privacy
   check_your_answers:
     title: Are you ready to send your application?
-    hint: Check your answers first
+    hint: Check your answers first.
     heading: Now send your application
     confirmation: By submitting this application you’re confirming that, as far as you know, the details you’re providing are correct.
     submit: Accept and send

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,9 +2,10 @@ en:
   privacy_notice:
     label: Privacy
   check_your_answers:
-    title: Check your answers before sending your application
+    title: Are you ready to send your application?
+    hint: Check your answers first
     heading: Now send your application
-    confirmation: By submitting this application you’re confirming that, to the best of your knowledge, the details you’re providing are correct.
+    confirmation: By submitting this application you’re confirming that, as far as you know, the details you’re providing are correct.
     submit: Accept and send
   not_eligible_medical:
     title: Sorry, you’re not eligible for help through this service


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/165

<img width="1552" alt="Screenshot 2020-03-24 at 16 29 07" src="https://user-images.githubusercontent.com/5793815/77452680-21817e00-6dee-11ea-87ee-a859d27d56cc.png">

