### PR TITLE
Update carry supplies question with description

### DIFF
--- a/app/views/coronavirus_form/carry_supplies.html.erb
+++ b/app/views/coronavirus_form/carry_supplies.html.erb
@@ -19,6 +19,7 @@
       heading: t("coronavirus_form.questions.carry_supplies.title"),
       is_page_heading: true,
       name: "carry_supplies",
+      description: sanitize(t("coronavirus_form.questions.carry_supplies.description")),
       error_message: error_items("carry_supplies"),
       items: t("coronavirus_form.questions.carry_supplies.options").map.with_index do |(_, item), index|
         {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,6 +263,8 @@ en:
         custom_select_error: Select yes if you have special dietary requirements
       carry_supplies:
         title: Is there someone in the house who’s able to carry a delivery of supplies inside?
+        description: |
+          <p class="govuk-inset-text">For now, we’ll need to leave deliveries on the doorstep.</p>
         options:
           option_yes:
             label: "Yes"


### PR DESCRIPTION
## What

Carry supplies question updated with description.

🂡 Card: https://trello.com/c/7RvCSySQ

## Why

To make it clear that any deliveries will need to be left at the door.

## Visual differences

Before on desktop:

![image](https://user-images.githubusercontent.com/1732331/77466979-08cf9300-6e03-11ea-9fe5-3042b1fc7643.png)

After on desktop:

![image](https://user-images.githubusercontent.com/1732331/77467002-11c06480-6e03-11ea-820c-64bdd6d120c1.png)


<table><tr><th>Before on mobile

</th><th>After on mobile

</th></tr><tr><td>

![image](https://user-images.githubusercontent.com/1732331/77466846-d1f97d00-6e02-11ea-8d9f-ff880dc24c9c.png)


</td><td>

![image](https://user-images.githubusercontent.com/1732331/77466824-c312ca80-6e02-11ea-8ddd-05bb4116d86c.png)


</td></tr></table>
