### PR TITLE
Put a guard around date of birth format

### DIFF
--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -33,7 +33,7 @@ module AnswersHelper
     elsif question.eql?("support_address")
       answer.values.compact.join(",<br>")
     elsif question.eql?("date_of_birth")
-      Time.zone.local(answer["year"], answer["month"], answer["day"]).strftime("%d/%m/%Y")
+      Time.zone.local(answer["year"], answer["month"], answer["day"]).strftime("%d/%m/%Y") if answer.present?
     else
       answer.values.compact.join(" ")
     end

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -112,6 +112,12 @@ RSpec.describe AnswersHelper, type: :helper do
         expected_answer = "31/01/1970"
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
+
+      it "returns nothing if the support_address is empty" do
+        answer = {}
+
+        expect(helper.concat_answer(answer, question)).to be_nil
+      end
     end
 
     context "general multipart questions" do


### PR DESCRIPTION
The date of birth field was erroring on the check answers page:

https://sentry.io/organizations/govuk/issues/1583080663/?environment=production&project=5170680&query=is%3Aunresolved

This is an attempt to fix that.