### PR TITLE
Add more guards to the date of birth

### DIFF
--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -33,10 +33,16 @@ module AnswersHelper
     elsif question.eql?("support_address")
       answer.values.compact.join(",<br>")
     elsif question.eql?("date_of_birth")
-      Time.zone.local(answer["year"], answer["month"], answer["day"]).strftime("%d/%m/%Y") if answer.present?
+      Time.zone.local(answer["year"], answer["month"], answer["day"]).strftime("%d/%m/%Y") if complete_date?(answer)
     else
       answer.values.compact.join(" ")
     end
+  end
+
+  def complete_date?(date)
+    date.present? &&
+      %w(day month year).all? { |required_key| date.key?(required_key) } &&
+      date.values.all?(&:present?)
   end
 
   def questions

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -113,8 +113,27 @@ RSpec.describe AnswersHelper, type: :helper do
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
 
-      it "returns nothing if the support_address is empty" do
+      it "returns nothing if the date_of_birth is empty" do
         answer = {}
+
+        expect(helper.concat_answer(answer, question)).to be_nil
+      end
+
+      it "returns nothing if part of the date is missing" do
+        answer = {
+          "month" => "01",
+          "day" => "31",
+        }
+
+        expect(helper.concat_answer(answer, question)).to be_nil
+      end
+
+      it "returns nothing if the date is nil" do
+        answer = {
+          "month" => nil,
+          "day" => nil,
+          "year" => nil,
+        }
 
         expect(helper.concat_answer(answer, question)).to be_nil
       end


### PR DESCRIPTION
This might be overkill, but https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/182 did not fix this error:
https://sentry.io/organizations/govuk/issues/1583162201/?environment=production&project=5170680

I'm not able to reproduce the problem locally, as the form doesn't let me submit an invalid or incomplete date. 
I'm not sure how this error is occurring, so I've added extra guards just in case.