### PR TITLE
Increase session timeout to 4 hours

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,1 @@
-Rails.application.config.session_store :cookie_store, expire_after: 2.hours
+Rails.application.config.session_store :cookie_store, expire_after: 4.hours


### PR DESCRIPTION
Trello: https://trello.com/c/Zuq2NJO6

We've seen ~20,000 requests (0.13% of total) have a 422 error, we think mostly due to session expiry.

Increasing this timeout by a couple of hours should reduce this error rate.

See: https://kibana.logit.io/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now%2Fd,to:now%2Fd))&_a=(columns:!(status,path,cf.app),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:kuery,query:'message:*InvalidAuthenticityToken*'),sort:!(!('@timestamp',desc)))