### PR TITLE
Use strip_tags to sanitize user input

### DIFF
--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -6,7 +6,7 @@ class CoronavirusForm::BasicCareNeedsController < ApplicationController
   end
 
   def submit
-    basic_care_needs = sanitize(params[:basic_care_needs]).presence
+    basic_care_needs = strip_tags(params[:basic_care_needs]).presence
     session[:basic_care_needs] = basic_care_needs
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/carry_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/carry_supplies_controller.rb
@@ -6,7 +6,7 @@ class CoronavirusForm::CarrySuppliesController < ApplicationController
   end
 
   def submit
-    carry_supplies = sanitize(params[:carry_supplies]).presence
+    carry_supplies = strip_tags(params[:carry_supplies]).presence
     session[:carry_supplies] = carry_supplies
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -7,9 +7,9 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
 
   def submit
     contact_details = {
-      "phone_number_calls" => sanitize(params[:phone_number_calls]&.strip).presence,
-      "phone_number_texts" => sanitize(params[:phone_number_texts]&.strip).presence,
-      "email" => sanitize(params[:email]&.strip).presence,
+      "phone_number_calls" => strip_tags(params[:phone_number_calls]&.strip).presence,
+      "phone_number_texts" => strip_tags(params[:phone_number_texts]&.strip).presence,
+      "email" => strip_tags(params[:email]&.strip).presence,
     }
     session[:contact_details] = contact_details
 

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -8,9 +8,9 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
 
   def submit
     session["date_of_birth"] ||= {}
-    session["date_of_birth"]["day"] = sanitize(params.dig("date_of_birth", "day")&.strip).presence
-    session["date_of_birth"]["month"] = sanitize(params.dig("date_of_birth", "month")&.strip).presence
-    session["date_of_birth"]["year"] = sanitize(params.dig("date_of_birth", "year")&.strip).presence
+    session["date_of_birth"]["day"] = strip_tags(params.dig("date_of_birth", "day")&.strip).presence
+    session["date_of_birth"]["month"] = strip_tags(params.dig("date_of_birth", "month")&.strip).presence
+    session["date_of_birth"]["year"] = strip_tags(params.dig("date_of_birth", "year")&.strip).presence
 
     invalid_fields = validate_date_of_birth(
       session["date_of_birth"]["year"],

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -6,7 +6,7 @@ class CoronavirusForm::DietaryRequirementsController < ApplicationController
   end
 
   def submit
-    dietary_requirements = sanitize(params[:dietary_requirements]).presence
+    dietary_requirements = strip_tags(params[:dietary_requirements]).presence
     session[:dietary_requirements] = dietary_requirements
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -6,7 +6,7 @@ class CoronavirusForm::EssentialSuppliesController < ApplicationController
   end
 
   def submit
-    essential_supplies = sanitize(params[:essential_supplies]).presence
+    essential_supplies = strip_tags(params[:essential_supplies]).presence
     session[:essential_supplies] = essential_supplies
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -6,7 +6,7 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
   end
 
   def submit
-    know_nhs_number = sanitize(params[:know_nhs_number]).presence
+    know_nhs_number = strip_tags(params[:know_nhs_number]).presence
     session[:know_nhs_number] = know_nhs_number
 
     session[:nhs_number] = nil if I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")

--- a/app/controllers/coronavirus_form/live_in_england_controller.rb
+++ b/app/controllers/coronavirus_form/live_in_england_controller.rb
@@ -8,7 +8,7 @@ class CoronavirusForm::LiveInEnglandController < ApplicationController
   end
 
   def submit
-    live_in_england = sanitize(params[:live_in_england]).presence
+    live_in_england = strip_tags(params[:live_in_england]).presence
     session[:live_in_england] = live_in_england
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -6,7 +6,7 @@ class CoronavirusForm::MedicalConditionsController < ApplicationController
   end
 
   def submit
-    medical_conditions = sanitize(params[:medical_conditions]).presence
+    medical_conditions = strip_tags(params[:medical_conditions]).presence
     session[:medical_conditions] = medical_conditions
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -8,9 +8,9 @@ class CoronavirusForm::NameController < ApplicationController
 
   def submit
     session["name"] ||= {}
-    session["name"]["first_name"] = sanitize(params[:first_name]&.strip).presence
-    session["name"]["middle_name"] = sanitize(params[:middle_name]&.strip).presence
-    session["name"]["last_name"] = sanitize(params[:last_name]&.strip).presence
+    session["name"]["first_name"] = strip_tags(params[:first_name]&.strip).presence
+    session["name"]["middle_name"] = strip_tags(params[:middle_name]&.strip).presence
+    session["name"]["last_name"] = strip_tags(params[:last_name]&.strip).presence
 
     invalid_fields = validate_text_fields(%w[first_name last_name], "name")
 

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -6,7 +6,7 @@ class CoronavirusForm::NhsLetterController < ApplicationController
   end
 
   def submit
-    nhs_letter = sanitize(params[:nhs_letter]).presence
+    nhs_letter = strip_tags(params[:nhs_letter]).presence
     session[:nhs_letter] = nhs_letter
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -9,7 +9,7 @@ class CoronavirusForm::NhsNumberController < ApplicationController
 
   def submit
     session[:nhs_number] ||= ""
-    session[:nhs_number] = sanitize(clean_nhs_number(params["nhs_number"])).presence
+    session[:nhs_number] = strip_tags(clean_nhs_number(params["nhs_number"])).presence
 
     invalid_fields = validate_fields(session[:nhs_number])
 

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -13,11 +13,11 @@ class CoronavirusForm::SupportAddressController < ApplicationController
 
   def submit
     session[:support_address] ||= {}
-    session[:support_address]["building_and_street_line_1"] = sanitize(params[:building_and_street_line_1]&.strip).presence
-    session[:support_address]["building_and_street_line_2"] = sanitize(params[:building_and_street_line_2]&.strip).presence
-    session[:support_address]["town_city"] = sanitize(params[:town_city]&.strip).presence
-    session[:support_address]["county"] = sanitize(params[:county]&.strip).presence
-    session[:support_address]["postcode"] = sanitize(params[:postcode]&.strip).presence
+    session[:support_address]["building_and_street_line_1"] = strip_tags(params[:building_and_street_line_1]&.strip).presence
+    session[:support_address]["building_and_street_line_2"] = strip_tags(params[:building_and_street_line_2]&.strip).presence
+    session[:support_address]["town_city"] = strip_tags(params[:town_city]&.strip).presence
+    session[:support_address]["county"] = strip_tags(params[:county]&.strip).presence
+    session[:support_address]["postcode"] = strip_tags(params[:postcode]&.strip).presence
 
     invalid_fields = validate_fields(session[:support_address])
 

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -31,6 +31,22 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       expect(session[session_key]).to eq params
     end
 
+    it "strips html characters" do
+      params = {
+        "phone_number_calls" => '<a href="https://www.example.com">Link</a>',
+        "phone_number_texts" => '<a href="https://www.example.com">Link</a>',
+      }
+
+      contact_details = {
+        "phone_number_calls" => "Link",
+        "phone_number_texts" => "Link",
+        "email" => nil,
+      }
+
+      post :submit, params: params
+      expect(session[session_key]).to eq contact_details
+    end
+
     it "redirects to next step for a permitted response" do
       post :submit, params: params
       expect(response).to redirect_to(medical_conditions_path)

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -39,6 +39,23 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
       expect(session[session_key]).to eq person
     end
 
+    it "strips html characters" do
+      params = {
+        "first_name" => '<a href="https://www.example.com">Link</a>',
+        "middle_name" => '<a href="https://www.example.com">Link</a>',
+        "last_name" => '<a href="https://www.example.com">Link</a>',
+      }
+
+      name = {
+        "first_name" => "Link",
+        "middle_name" => "Link",
+        "last_name" => "Link",
+      }
+
+      post :submit, params: params
+      expect(session[session_key]).to eq name
+    end
+
     %w(first_name last_name).each do |field|
       it "validates #{field} is required" do
         post :submit, params: params.except(field)

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       expect(session[session_key]).to eq address
     end
 
+    it "strips html characters" do
+      params = {
+        "building_and_street_line_1" => '<a href="https://www.example.com">Link</a>',
+        "building_and_street_line_2" => '<a href="https://www.example.com">Link</a>',
+        "town_city" => '<a href="https://www.example.com">Link</a>',
+        "county" => '<a href="https://www.example.com">Link</a>',
+      }
+
+      address = {
+        "building_and_street_line_1" => "Link",
+        "building_and_street_line_2" => "Link",
+        "town_city" => "Link",
+        "county" => "Link",
+        "postcode" => nil,
+      }
+
+      post :submit, params: params
+      expect(session[session_key]).to eq address
+    end
+
     it "does not require address line 2" do
       post :submit, params: params.except("building_and_street_line_2")
 


### PR DESCRIPTION
Trello: https://trello.com/c/fcpAev6f

# What's changed?
Use `strip_tags` rather than `sanitize` to sanitise user input.
`sanitize` only removes what are considered unsafe protocols, like `javascript:`.
`strip_tags` goes further and removes all html tags.
See: https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-strip_tags

# Why?
If users entered <img> or <a> tags the application would render it.
So someone could create a malicious link that directs to a nasty site and it render it as a hyperlink without showing the URL.
With more time and resource an attacker might be able to do something nasty with this.