### PR TITLE
Redirect to session expired page if a user's session expires

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
 
+  rescue_from ActionController::InvalidAuthenticityToken, with: :session_expired
+
   before_action :check_first_question, only: [:show]
 
   def show
@@ -29,6 +31,11 @@ private
 
   def log_validation_error(invalid_fields)
     logger.info "validation error - #{invalid_fields.pluck(:text).to_sentence}"
+  end
+
+  def session_expired
+    reset_session
+    redirect_to session_expired_path
   end
 
   def check_first_question

--- a/app/controllers/coronavirus_form/session_expired_controller.rb
+++ b/app/controllers/coronavirus_form/session_expired_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::SessionExpiredController < ApplicationController
+  skip_before_action :check_first_question
+end

--- a/app/views/coronavirus_form/session_expired.html.erb
+++ b/app/views/coronavirus_form/session_expired.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title do %><%= t('session_expired.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('session_expired.title') %>" />
+<% end %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title:t("session_expired.title"),
+  margin_top: 0
+} %>
+
+<%= sanitize(t('session_expired.body_text')) %>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: "Start now",
+  start: true,
+  href: "/"
+} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,12 @@ en:
 
       <h2 class="govuk-heading-m">Changes to this notice</h2>
       <p class="govuk-body">We may change this privacy notice. When we make changes to this notice, the ‘last updated’ date at the top of this page will also change. Any changes to this privacy notice will apply to you and your information immediately. If these changes affect how your personal information is processed, the Cabinet Office will take reasonable steps to make sure you know.</p>
+  session_expired:
+    title: Your session has ended due to inactivity
+    body_text: |
+      <p class="govuk-body">Your session has ended because you have not done anything for 4 hours. You'll have to start again.</p>
+
+      <p class="govuk-body">We do this for your security. We've deleted all the details you entered to protect your data.</p>
   coronavirus_form:
     errors:
       page_title_prefix: 'Error: '

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   scope module: "coronavirus_form" do
     get "/privacy", to: "privacy#show"
 
+    get "/session-expired", to: "session_expired#show"
+
     # (v4[sunday]) Question 1: Do you live in England?
     get "/live-in-england", to: "live_in_england#show"
     post "/live-in-england", to: "live_in_england#submit"

--- a/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::BasicCareNeedsController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/basic_care_needs" }
   let(:session_key) { :basic_care_needs }

--- a/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/carry_supplies" }
   let(:session_key) { :carry_supplies }

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/check_answers" }
 

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/contact_details" }
   let(:session_key) { :contact_details }

--- a/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/date_of_birth" }
   let(:session_key) { "date_of_birth" }

--- a/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/dietary_requirements" }
   let(:session_key) { :dietary_requirements }

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/essential_supplies" }
   let(:session_key) { :essential_supplies }

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/know_nhs_number" }
   let(:session_key) { :know_nhs_number }

--- a/spec/controllers/coronavirus_form/live_in_england_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/live_in_england_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::LiveInEnglandController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/live_in_england" }
   let(:session_key) { :live_in_england }
 

--- a/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/medical_conditions" }
   let(:session_key) { :medical_conditions }

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::NameController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/name" }
   let(:session_key) { :name }

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/nhs_letter" }
   let(:session_key) { :nhs_letter }

--- a/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::NhsNumberController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/nhs_number" }
   let(:session_key) { :nhs_number }

--- a/spec/controllers/coronavirus_form/session_expired_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/session_expired_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::SessionExpiredController, type: :controller do
+  let(:current_template) { "coronavirus_form/session_expired" }
+
+  describe "GET show" do
+    it "renders the page" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
   include_examples "redirections"
+  include_examples "session expiry"
 
   let(:current_template) { "coronavirus_form/support_address" }
   let(:session_key) { :support_address }

--- a/spec/support/shared_examples_for_controllers.rb
+++ b/spec/support/shared_examples_for_controllers.rb
@@ -4,3 +4,12 @@ RSpec.shared_examples "redirections" do
     expect(response).to redirect_to(live_in_england_path)
   end
 end
+
+RSpec.shared_examples "session expiry" do
+  it "redirects to session expired page if the session has timed out" do
+    allow(controller).to receive(:submit).and_raise(ActionController::InvalidAuthenticityToken)
+
+    post :submit
+    expect(response).to redirect_to(session_expired_path)
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/4vyXO6Ww

# What's changed?
Show a "session has expired" page when user's session expires.

# Why?
Users were being shown a generic rails "the change you wanted was rejected" page which was causing a lot of confusion.

# Expected changes
## Before
![image](https://user-images.githubusercontent.com/5793815/77906051-30997d80-727f-11ea-983d-a62ff614e62c.png)

## After
<img width="1552" alt="Screenshot 2020-03-30 at 11 55 36" src="https://user-images.githubusercontent.com/5793815/77905721-acdf9100-727e-11ea-8a45-ab7ef9236a7e.png">

# Testing locally
change the `expire_after` value in the [session store config](https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/blob/master/config/initializers/session_store.rb) to `1.minute`