### PR TITLE
Only run 1 smoke test against prod at any one time

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -100,6 +100,7 @@ jobs:
           HOSTNAME: govuk-coronavirus-vulnerable-people-form-prod
 
   - name: smoke-test-prod
+    serial: true
     plan:
       - get: govuk-coronavirus-vulnerable-people-form
         trigger: true


### PR DESCRIPTION
This PR makes sure multiple `smoke-test-prod` jobs stack up, and don't run all at once.

Whilst this is proposed in order to enable a later PR to trigger the smoke test periodically, with timeouts, this PR can safely be merged (after review!) as the current pipeline behaviour has serial-ness implied by this job's dependency on `deploy-to-prod` which is itself `serial: true`