### PR TITLE
Make prod smoke tests fail if they take too long

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -106,6 +106,7 @@ jobs:
         passed: [deploy-to-prod]
       - task: smoke-test
         file: govuk-coronavirus-vulnerable-people-form/concourse/tasks/smoke-test.yml
+        timeout: 5m
         params:
           URL: 'https://govuk-coronavirus-vulnerable-people-form-prod.cloudapps.digital/'
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes. If this fails, you should investigate immediately."


### PR DESCRIPTION
Production smoke tests can currently run forever without failing.

This PR places an arbitrary (but hopefully way-too-long) 5 minute timeout on the prod smoke test job.

It kinda-sorta builds on #190, but could be merged seperately.