### PR TITLE
Run prod smoke tests every 30 minutes

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -28,6 +28,11 @@ resources:
       branch: master
       pro: true
 
+  - name: every-30m
+    type: time
+    source:
+      interval: 30m
+
 jobs:
   - name: deploy-to-staging
     serial: true
@@ -101,6 +106,8 @@ jobs:
 
   - name: smoke-test-prod
     plan:
+      - get: every-30m
+        trigger: true
       - get: govuk-coronavirus-vulnerable-people-form
         trigger: true
         passed: [deploy-to-prod]


### PR DESCRIPTION
Absent any other form of uptime monitoring, this checks the prod app is serving pages correctly every 30 minutes.

This PR builds on #190 and #191, and provides very rudimentary uptime checking - possibly useful if the team's not had the chance to set that up elsewhere in GDS' monitoring.