### PR TITLE
Make smoke tests follow HTTP redirects

### DIFF
--- a/concourse/tasks/smoke-test.yml
+++ b/concourse/tasks/smoke-test.yml
@@ -16,4 +16,4 @@ run:
       echo "$MESSAGE"
 
       # TODO we can come up with a more thorough test than this
-      curl --fail --silent --verbose --user gds:((basic-auth-password)) "$URL"
+      curl --fail --silent --verbose --location --user gds:((basic-auth-password)) "$URL"


### PR DESCRIPTION
Currently, at least 1 of the 2 invocations of the smoke test script (prod smoke test CD job) are testing a URL which emits highly-CDN-cacheable redirects to the public-facing gov.uk URL.

Without this`--location` it's possible the redirects would be correctly served from cache, but the app itself could be dead, but this script would not notice.

This PR makes the smoke test follow all 3XX responses and assert the 2XX-ness of the URL being consumed by the public.