### PR TITLE
Container image to run feature tests in pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+tmp
+vendor

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -28,7 +28,24 @@ resources:
       branch: master
       pro: true
 
+  - name: feature-tests-image
+    type: docker-image
+    icon: docker
+    source:
+      repository: ((readonly_private_ecr_repo_url))
+      tag: govuk-coronavirus-vulnerable-people-form-feature-tests
+
 jobs:
+  - name: build-feature-tests-image
+    serial: true
+    plan:
+      - get: govuk-coronavirus-vulnerable-people-form
+        trigger: true
+      - put: feature-tests-image
+        params:
+          build: govuk-coronavirus-vulnerable-people-form
+          dockerfile: govuk-coronavirus-vulnerable-people-form/features/Dockerfile
+
   - name: deploy-to-staging
     serial: true
     plan:
@@ -54,7 +71,7 @@ jobs:
     plan:
       - get: govuk-coronavirus-vulnerable-people-form
         trigger: true
-        passed: [deploy-to-staging]
+        passed: [deploy-to-staging, build-feature-tests-image]
       - task: smoke-test
         file: govuk-coronavirus-vulnerable-people-form/concourse/tasks/smoke-test.yml
         params:
@@ -73,11 +90,10 @@ jobs:
 
             If you urgently need to deploy a CSS change, and you can accept a few minutes of unstyled pages being served to users, you can disable this task with /fly set-pipeline/
 
-      # TODO : This task needs a container that has chrome in it, otherwise it won't work
-      # - task: run-cucumber-specs
-      #   file: govuk-coronavirus-vulnerable-people-form/concourse/tasks/run-cucumber-specs.yml
-      #   params:
-      #     TEST_URL: 'https://gds:((basic-auth-password))@govuk-coronavirus-vulnerable-people-form-stg.cloudapps.digital'
+      - task: run-cucumber-specs
+        file: govuk-coronavirus-vulnerable-people-form/concourse/tasks/run-cucumber-specs.yml
+        params:
+          TEST_URL: 'https://gds:((basic-auth-password))@govuk-coronavirus-vulnerable-people-form-stg.cloudapps.digital'
 
   - name: deploy-to-prod
     serial: true

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -19,6 +19,22 @@ resources:
       uri: https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form
       branch: master
 
+  - name: govuk-coronavirus-vulnerable-people-form-feature-tests
+    type: git
+    icon: github-circle
+    source:
+      uri: https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form
+      branch: master
+      paths:
+        - Gemfile*
+        - .ruby-version
+        - features/
+
+  - name: every-day
+    type: time
+    source:
+      interval: 24h
+
   - name: govuk-coronavirus-vulnerable-people-form-travis-build
     type: travis
     icon: sync
@@ -39,7 +55,9 @@ jobs:
   - name: build-feature-tests-image
     serial: true
     plan:
-      - get: govuk-coronavirus-vulnerable-people-form
+      - get: every-day
+        trigger: true
+      - get: govuk-coronavirus-vulnerable-people-form-feature-tests
         trigger: true
       - put: feature-tests-image
         params:

--- a/concourse/tasks/run-cucumber-specs.yml
+++ b/concourse/tasks/run-cucumber-specs.yml
@@ -2,23 +2,13 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    # TODO: This container needs to include Chrome, otherwise capybara/apparition won't work
-    repository: ruby
-    tag: 2.6.5
+    repository: ((readonly_private_ecr_repo_url))
+    tag: govuk-coronavirus-vulnerable-people-form-feature-tests
 params:
   TEST_URL:
 inputs:
   - name: govuk-coronavirus-vulnerable-people-form
-    path: src
-caches:
-  - path: vendor/bundle
 run:
-  path: sh
-  dir: src
-  args:
-    - '-c'
-    - |
-      set -eu
-
-      bundle install --path ../vendor/bundle
-      bundle exec rails cucumber
+  path: rails
+  dir: govuk-coronavirus-vulnerable-people-form
+  args: ['cucumber']

--- a/features/Dockerfile
+++ b/features/Dockerfile
@@ -1,0 +1,27 @@
+#========================================================================================
+# This Dockerfile creates a container image which contains ruby and google chrome,
+# as well as the application source and bundled dependencies.
+#
+# This is needed for running the feature tests in a container environment like concourse.
+#========================================================================================
+FROM ruby:2.6.5-buster
+
+RUN apt-get update --fix-missing && apt-get -y upgrade \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /src/*.deb
+
+ENV CHROME_NO_SANDBOX=true
+
+COPY Gemfile* .ruby-version /home/chrome/src/
+
+WORKDIR /home/chrome/src
+
+RUN bundle install
+
+COPY . /home/chrome/src/
+
+ENTRYPOINT ["/bin/bash"]

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,6 +8,15 @@ else
   require "capybara/apparition"
   require "capybara/cucumber"
   require "capybara/rspec"
+
+  Capybara.register_driver :apparition do |app|
+    options = { browser_options: {} }
+    if ENV.key? "CHROME_NO_SANDBOX"
+      options[:browser_options]["no-sandbox"] = true
+    end
+    Capybara::Apparition::Driver.new(app, options)
+  end
+
   Capybara.default_driver = :apparition
   Capybara.app_host = test_url
 end


### PR DESCRIPTION
Build a container that includes:

- ruby
- google chrome
- the application source code
- the application's dependencies

This is everything we need to run the feature tests against a remote URL
(previously we couldn't do this because we didn't have a container with
both ruby and chrome in).

We can get concourse to build this and upload it to the private Amazon
ECR (elastic container registry) that comes with the govuk-tools
concourse team (this is specific to GDS RE's concourse - see
https://reliability-engineering.cloudapps.digital/continuous-deployment.html#services)

Once we've got an image, we can use that to run the feature tests
against the staging URL.

We shouldn't run these tests against production yet, because they submit
the form, so they'd end up polluting live data. We could flag them so
they don't submit in staging though.

It's possible that building this image on every commit to master (and
blocking the pipeline on a clean build of the image) might turn out to
slow things down unacceptably. If that's the case we can look at caching
a base image or some other optimisation.