### PR TITLE
Remove the PAGE and NEXT_PAGE constants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,9 @@ class ApplicationController < ActionController::Base
 
   before_action :check_first_question, only: [:show]
 
-  def show; end
+  def show
+    render controller_path
+  end
 
   if ENV["REQUIRE_BASIC_AUTH"]
     http_basic_authenticate_with(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,9 @@ class ApplicationController < ActionController::Base
   before_action :check_first_question, only: [:show]
 
   def show
-    render controller_path
+    respond_to do |format|
+      format.html { render controller_path }
+    end
   end
 
   if ENV["REQUIRE_BASIC_AUTH"]

--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -1,34 +1,27 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::BasicCareNeedsController < ApplicationController
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     basic_care_needs = sanitize(params[:basic_care_needs]).presence
     session[:basic_care_needs] = basic_care_needs
 
     invalid_fields = validate_radio_field(
-      PAGE,
+      controller_name,
       radio: basic_care_needs,
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to dietary_requirements_url
     end
   end
 
 private
-
-  PAGE = "basic_care_needs"
-  NEXT_PAGE = "dietary_requirements"
 
   def previous_path
     essential_supplies_path

--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -13,7 +13,10 @@ class CoronavirusForm::BasicCareNeedsController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session["check_answers_seen"]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/carry_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/carry_supplies_controller.rb
@@ -13,7 +13,10 @@ class CoronavirusForm::CarrySuppliesController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     else
       redirect_to check_your_answers_url
     end

--- a/app/controllers/coronavirus_form/carry_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/carry_supplies_controller.rb
@@ -1,34 +1,25 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::CarrySuppliesController < ApplicationController
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     carry_supplies = sanitize(params[:carry_supplies]).presence
     session[:carry_supplies] = carry_supplies
 
     invalid_fields = validate_radio_field(
-      PAGE,
+      controller_name,
       radio: carry_supplies,
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
-    elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      render controller_path, status: :unprocessable_entity
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to check_your_answers_url
     end
   end
 
 private
-
-  PAGE = "carry_supplies"
-  NEXT_PAGE = "check_answers"
 
   def previous_path
     dietary_requirements_path

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -5,7 +5,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
   def show
     session[:check_answers_seen] = true
-    render "coronavirus_form/check_answers"
+    super
   end
 
   def submit
@@ -21,7 +21,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
     reset_session
 
-    redirect_to controller: "coronavirus_form/confirmation", action: "show", reference_number: submission_reference
+    redirect_to confirmation_url(reference_number: submission_reference)
   end
 
 private

--- a/app/controllers/coronavirus_form/confirmation_controller.rb
+++ b/app/controllers/coronavirus_form/confirmation_controller.rb
@@ -2,8 +2,4 @@
 
 class CoronavirusForm::ConfirmationController < ApplicationController
   skip_before_action :check_first_question
-
-  def show
-    render "coronavirus_form/confirmation"
-  end
 end

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::ContactDetailsController < ApplicationController
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     contact_details = {
       "phone_number_calls" => sanitize(params[:phone_number_calls]&.strip).presence,
@@ -18,18 +14,15 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to medical_conditions_url
     end
   end
 
 private
-
-  PAGE = "contact_details"
-  NEXT_PAGE = "medical_conditions"
 
   def previous_path
     support_address_path

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -14,7 +14,10 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session["check_answers_seen"]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -3,7 +3,7 @@
 class CoronavirusForm::DateOfBirthController < ApplicationController
   def show
     session["date_of_birth"] ||= {}
-    render "coronavirus_form/#{PAGE}"
+    super
   end
 
   def submit
@@ -22,18 +22,15 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to support_address_url
     end
   end
 
 private
-
-  PAGE = "date_of_birth"
-  NEXT_PAGE = "support_address"
 
   def previous_path
     name_path

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -22,7 +22,10 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session["check_answers_seen"]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -1,34 +1,27 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::DietaryRequirementsController < ApplicationController
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     dietary_requirements = sanitize(params[:dietary_requirements]).presence
     session[:dietary_requirements] = dietary_requirements
 
     invalid_fields = validate_radio_field(
-      PAGE,
+      controller_name,
       radio: dietary_requirements,
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to carry_supplies_url
     end
   end
 
 private
-
-  PAGE = "dietary_requirements"
-  NEXT_PAGE = "carry_supplies"
 
   def previous_path
     basic_care_needs_path

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -13,7 +13,10 @@ class CoronavirusForm::DietaryRequirementsController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session["check_answers_seen"]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -1,34 +1,27 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::EssentialSuppliesController < ApplicationController
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     essential_supplies = sanitize(params[:essential_supplies]).presence
     session[:essential_supplies] = essential_supplies
 
     invalid_fields = validate_radio_field(
-      PAGE,
+      controller_name,
       radio: essential_supplies,
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to basic_care_needs_url
     end
   end
 
 private
-
-  PAGE = "essential_supplies"
-  NEXT_PAGE = "basic_care_needs"
 
   def previous_path
     return nhs_number_path if session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label")

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -13,7 +13,10 @@ class CoronavirusForm::EssentialSuppliesController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session["check_answers_seen"]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -15,7 +15,10 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label")
       redirect_to nhs_number_url
     elsif session["check_answers_seen"]

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::KnowNhsNumberController < ApplicationController
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     know_nhs_number = sanitize(params[:know_nhs_number]).presence
     session[:know_nhs_number] = know_nhs_number
@@ -12,27 +8,24 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
     session[:nhs_number] = nil if I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
 
     invalid_fields = validate_radio_field(
-      PAGE,
+      controller_name,
       radio: know_nhs_number,
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label")
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to nhs_number_url
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
-      redirect_to controller: "coronavirus_form/essential_supplies", action: "show"
+      redirect_to essential_supplies_url
     end
   end
 
 private
-
-  PAGE = "know_nhs_number"
-  NEXT_PAGE = "nhs_number"
 
   def previous_path
     medical_conditions_path

--- a/app/controllers/coronavirus_form/live_in_england_controller.rb
+++ b/app/controllers/coronavirus_form/live_in_england_controller.rb
@@ -15,7 +15,10 @@ class CoronavirusForm::LiveInEnglandController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session[:live_in_england] == I18n.t("coronavirus_form.questions.live_in_england.options.option_no.label")
       redirect_to not_eligible_england_url
     elsif session["check_answers_seen"]

--- a/app/controllers/coronavirus_form/live_in_england_controller.rb
+++ b/app/controllers/coronavirus_form/live_in_england_controller.rb
@@ -3,36 +3,29 @@
 class CoronavirusForm::LiveInEnglandController < ApplicationController
   skip_before_action :check_first_question
 
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     live_in_england = sanitize(params[:live_in_england]).presence
     session[:live_in_england] = live_in_england
 
     invalid_fields = validate_radio_field(
-      PAGE,
+      controller_name,
       radio: live_in_england,
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session[:live_in_england] == I18n.t("coronavirus_form.questions.live_in_england.options.option_no.label")
-      redirect_to controller: "coronavirus_form/not_eligible_england", action: "show"
+      redirect_to not_eligible_england_url
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to nhs_letter_url
     end
   end
 
 private
-
-  PAGE = "live_in_england"
-  NEXT_PAGE = "nhs_letter"
 
   def previous_path
     "/"

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -13,7 +13,10 @@ class CoronavirusForm::MedicalConditionsController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session[:medical_conditions] == I18n.t("coronavirus_form.questions.medical_conditions.options.option_no.label")
       redirect_to not_eligible_medical_url
     elsif session["check_answers_seen"]

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -1,36 +1,29 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::MedicalConditionsController < ApplicationController
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     medical_conditions = sanitize(params[:medical_conditions]).presence
     session[:medical_conditions] = medical_conditions
 
     invalid_fields = validate_radio_field(
-      PAGE,
+      controller_name,
       radio: medical_conditions,
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session[:medical_conditions] == I18n.t("coronavirus_form.questions.medical_conditions.options.option_no.label")
-      redirect_to controller: "coronavirus_form/not_eligible_medical", action: "show"
+      redirect_to not_eligible_medical_url
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to know_nhs_number_url
     end
   end
 
 private
-
-  PAGE = "medical_conditions"
-  NEXT_PAGE = "know_nhs_number"
 
   def previous_path
     contact_details_path

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -17,7 +17,10 @@ class CoronavirusForm::NameController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session["check_answers_seen"]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -3,7 +3,7 @@
 class CoronavirusForm::NameController < ApplicationController
   def show
     session["name"] ||= {}
-    render "coronavirus_form/#{PAGE}"
+    super
   end
 
   def submit
@@ -17,18 +17,15 @@ class CoronavirusForm::NameController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to date_of_birth_url
     end
   end
 
 private
-
-  PAGE = "name"
-  NEXT_PAGE = "date_of_birth"
 
   def validate_text_fields(mandatory_fields, page)
     mandatory_fields.each_with_object([]) do |field, invalid_fields|

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -13,7 +13,10 @@ class CoronavirusForm::NhsLetterController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session["check_answers_seen"]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -1,34 +1,27 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::NhsLetterController < ApplicationController
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     nhs_letter = sanitize(params[:nhs_letter]).presence
     session[:nhs_letter] = nhs_letter
 
     invalid_fields = validate_radio_field(
-      PAGE,
+      controller_name,
       radio: nhs_letter,
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to name_url
     end
   end
 
 private
-
-  PAGE = "nhs_letter"
-  NEXT_PAGE = "name"
 
   def previous_path
     live_in_england_path

--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -3,10 +3,6 @@
 class CoronavirusForm::NhsNumberController < ApplicationController
   include NhsNumberValidatorHelper
 
-  def show
-    render "coronavirus_form/#{PAGE}"
-  end
-
   def submit
     session[:nhs_number] ||= ""
     session[:nhs_number] = sanitize(clean_nhs_number(params["nhs_number"])).presence
@@ -16,11 +12,11 @@ class CoronavirusForm::NhsNumberController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to essential_supplies_url
     end
   end
 
@@ -41,9 +37,6 @@ private
       },
     ]
   end
-
-  PAGE = "nhs_number"
-  NEXT_PAGE = "essential_supplies"
 
   def previous_path
     know_nhs_number_path

--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -12,7 +12,10 @@ class CoronavirusForm::NhsNumberController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session["check_answers_seen"]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/not_eligible_england_controller.rb
+++ b/app/controllers/coronavirus_form/not_eligible_england_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::NotEligibleEnglandController < ApplicationController
-  def show
-    render "coronavirus_form/not_eligible_england"
-  end
-
 private
 
   def previous_path

--- a/app/controllers/coronavirus_form/not_eligible_medical_controller.rb
+++ b/app/controllers/coronavirus_form/not_eligible_medical_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::NotEligibleMedicalController < ApplicationController
-  def show
-    render "coronavirus_form/not_eligible_medical"
-  end
-
 private
 
   def previous_path

--- a/app/controllers/coronavirus_form/privacy_controller.rb
+++ b/app/controllers/coronavirus_form/privacy_controller.rb
@@ -2,8 +2,4 @@
 
 class CoronavirusForm::PrivacyController < ApplicationController
   skip_before_action :check_first_question
-
-  def show
-    render "coronavirus_form/privacy"
-  end
 end

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -24,7 +24,10 @@ class CoronavirusForm::SupportAddressController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render controller_path, status: :unprocessable_entity
+
+      respond_to do |format|
+        format.html { render controller_path, status: :unprocessable_entity }
+      end
     elsif session["check_answers_seen"]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -8,7 +8,7 @@ class CoronavirusForm::SupportAddressController < ApplicationController
 
   def show
     session[:support_address] ||= {}
-    render "coronavirus_form/#{PAGE}"
+    super
   end
 
   def submit
@@ -24,18 +24,15 @@ class CoronavirusForm::SupportAddressController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
-      render "coronavirus_form/#{PAGE}", status: :unprocessable_entity
+      render controller_path, status: :unprocessable_entity
     elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+      redirect_to check_your_answers_url
     else
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to contact_details_url
     end
   end
 
 private
-
-  PAGE = "support_address"
-  NEXT_PAGE = "contact_details"
 
   def validate_fields(support_address)
     [
@@ -71,9 +68,9 @@ private
 
       invalid_fields << {
         field: field.to_s,
-        text: t("coronavirus_form.questions.#{PAGE}.#{field}.custom_error",
+        text: t("coronavirus_form.questions.#{controller_name}.#{field}.custom_error",
                 default: t("coronavirus_form.errors.missing_mandatory_text_field",
-                           field: t("coronavirus_form.questions.#{PAGE}.#{field}.label")).humanize),
+                           field: t("coronavirus_form.questions.#{controller_name}.#{field}.label")).humanize),
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,72 +4,74 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 
-  get "/" => redirect("https://www.gov.uk/coronavirus-extremely-vulnerable")
+  get "/", to: redirect("https://www.gov.uk/coronavirus-extremely-vulnerable")
 
-  get "/privacy", to: "coronavirus_form/privacy#show"
+  scope module: "coronavirus_form" do
+    get "/privacy", to: "privacy#show"
 
-  # (v4[sunday]) Question 1: Do you live in England?
-  get "/live-in-england", to: "coronavirus_form/live_in_england#show"
-  post "/live-in-england", to: "coronavirus_form/live_in_england#submit"
+    # (v4[sunday]) Question 1: Do you live in England?
+    get "/live-in-england", to: "live_in_england#show"
+    post "/live-in-england", to: "live_in_england#submit"
 
-  # (v4[sunday]) Question 2: Have you recently had a letter from the NHS...
-  get "/nhs-letter", to: "coronavirus_form/nhs_letter#show"
-  post "/nhs-letter", to: "coronavirus_form/nhs_letter#submit"
+    # (v4[sunday]) Question 2: Have you recently had a letter from the NHS...
+    get "/nhs-letter", to: "nhs_letter#show"
+    post "/nhs-letter", to: "nhs_letter#submit"
 
-  # (v4[sunday]) Question 3: What is your name?
-  get "/name", to: "coronavirus_form/name#show"
-  post "/name", to: "coronavirus_form/name#submit"
+    # (v4[sunday]) Question 3: What is your name?
+    get "/name", to: "name#show"
+    post "/name", to: "name#submit"
 
-  # (v4[sunday]) Question 4: What is your date of birth?
-  get "/date-of-birth", to: "coronavirus_form/date_of_birth#show"
-  post "/date-of-birth", to: "coronavirus_form/date_of_birth#submit"
+    # (v4[sunday]) Question 4: What is your date of birth?
+    get "/date-of-birth", to: "date_of_birth#show"
+    post "/date-of-birth", to: "date_of_birth#submit"
 
-  # (v4[sunday]) Question 5: Address where support is needed
-  get "/support-address" => "coronavirus_form/support_address#show"
-  post "/support-address" => "coronavirus_form/support_address#submit"
+    # (v4[sunday]) Question 5: Address where support is needed
+    get "/support-address", to: "support_address#show"
+    post "/support-address", to: "support_address#submit"
 
-  # (v4[sunday]) Question 6: Enter your contact details
-  get "/contact-details", to: "coronavirus_form/contact_details#show"
-  post "/contact-details", to: "coronavirus_form/contact_details#submit"
+    # (v4[sunday]) Question 6: Enter your contact details
+    get "/contact-details", to: "contact_details#show"
+    post "/contact-details", to: "contact_details#submit"
 
-  # (v4[sunday]) Question 7: Do you have a medical condition that makes you vulnerable to coronavirus?
-  get "/medical-conditions", to: "coronavirus_form/medical_conditions#show"
-  post "/medical-conditions", to: "coronavirus_form/medical_conditions#submit"
+    # (v4[sunday]) Question 7: Do you have a medical condition that makes you vulnerable to coronavirus?
+    get "/medical-conditions", to: "medical_conditions#show"
+    post "/medical-conditions", to: "medical_conditions#submit"
 
-  # (v4[sunday]) Question 8.1: Do you know your NHS number?
-  get "/know-nhs-number", to: "coronavirus_form/know_nhs_number#show"
-  post "/know-nhs-number", to: "coronavirus_form/know_nhs_number#submit"
+    # (v4[sunday]) Question 8.1: Do you know your NHS number?
+    get "/know-nhs-number", to: "know_nhs_number#show"
+    post "/know-nhs-number", to: "know_nhs_number#submit"
 
-  # (v4[sunday]) Question 8.2: What is your NHS number
-  get "/nhs-number" => "coronavirus_form/nhs_number#show"
-  post "/nhs-number" => "coronavirus_form/nhs_number#submit"
+    # (v4[sunday]) Question 8.2: What is your NHS number
+    get "/nhs-number", to: "nhs_number#show"
+    post "/nhs-number", to: "nhs_number#submit"
 
-  # (v4[sunday]) Question 9: Do you have a way of getting essential supplies delivered?
-  get "/essential-supplies", to: "coronavirus_form/essential_supplies#show"
-  post "/essential-supplies", to: "coronavirus_form/essential_supplies#submit"
+    # (v4[sunday]) Question 9: Do you have a way of getting essential supplies delivered?
+    get "/essential-supplies", to: "essential_supplies#show"
+    post "/essential-supplies", to: "essential_supplies#submit"
 
-  # (v4[sunday]) Question 10: Are your basic care needs being met at the moment?
-  get "/basic-care-needs", to: "coronavirus_form/basic_care_needs#show"
-  post "/basic-care-needs", to: "coronavirus_form/basic_care_needs#submit"
+    # (v4[sunday]) Question 10: Are your basic care needs being met at the moment?
+    get "/basic-care-needs", to: "basic_care_needs#show"
+    post "/basic-care-needs", to: "basic_care_needs#submit"
 
-  # (v4[sunday]) Question 11: Do you have any special dietary requirements?
-  get "/dietary-requirements", to: "coronavirus_form/dietary_requirements#show"
-  post "/dietary-requirements", to: "coronavirus_form/dietary_requirements#submit"
+    # (v4[sunday]) Question 11: Do you have any special dietary requirements?
+    get "/dietary-requirements", to: "dietary_requirements#show"
+    post "/dietary-requirements", to: "dietary_requirements#submit"
 
-  # (v4[sunday]) Question 12: Is there someone in the house who's able to carry a delivery of supplies inside?
-  get "/carry-supplies", to: "coronavirus_form/carry_supplies#show"
-  post "/carry-supplies", to: "coronavirus_form/carry_supplies#submit"
+    # (v4[sunday]) Question 12: Is there someone in the house who's able to carry a delivery of supplies inside?
+    get "/carry-supplies", to: "carry_supplies#show"
+    post "/carry-supplies", to: "carry_supplies#submit"
 
-  # Check answers page
-  get "/check-your-answers" => "coronavirus_form/check_answers#show"
-  post "/check-your-answers" => "coronavirus_form/check_answers#submit"
+    # Check answers page
+    get "/check-your-answers", to: "check_answers#show"
+    post "/check-your-answers", to: "check_answers#submit"
 
-  # Not eligible for supplies
-  get "/not-eligible-medical" => "coronavirus_form/not_eligible_medical#show"
+    # Not eligible for supplies
+    get "/not-eligible-medical", to: "not_eligible_medical#show"
 
-  # Person isn't eligible if not in England
-  get "/not-eligible-england" => "coronavirus_form/not_eligible_england#show"
+    # Person isn't eligible if not in England
+    get "/not-eligible-england", to: "not_eligible_england#show"
 
-  # Final page
-  get "/confirmation" => "coronavirus_form/confirmation#show"
+    # Final page
+    get "/confirmation", to: "confirmation#show"
+  end
 end


### PR DESCRIPTION
The PAGE constant can be replaced by either the controller_name for the field name or controller_path for the template name. The NEXT_PAGE constant can be replaced by named url helpers which are faster to generate than options passed to url_for (which is what happens internally inside the redirect_to method).

This conflicts with #184 which uses path helpers for the redirect_to but url helpers are preferred because the first check inside redirect_to is for a string that starts with a protocol and then it next checks if the argument is a string and if so prepends the protocol and host name with the port. This technically makes it slightly faster but you'd never notice in reality.