### PR TITLE
Add accessibility statement

### DIFF
--- a/app/controllers/coronavirus_form/accessibility_statement_controller.rb
+++ b/app/controllers/coronavirus_form/accessibility_statement_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::AccessibilityStatementController < ApplicationController
+  skip_before_action :check_first_question
+end

--- a/app/views/coronavirus_form/accessibility_statement.html.erb
+++ b/app/views/coronavirus_form/accessibility_statement.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %><%= t('accessibility_statement.title') %><% end %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title:t("accessibility_statement.title"),
+  margin_top: 0
+} %>
+
+<%= sanitize(t('accessibility_statement.body_text')) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,11 @@
         items: [
           {
             href: "/privacy",
-            text: t("privacy_notice.label")
+            text: t("privacy_page.title")
+          },
+          {
+            href: "/accessibility-statement",
+            text: t("accessibility_statement.title")
           },
         ]
       }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,4 @@
 en:
-  privacy_notice:
-    label: Privacy
   check_your_answers:
     title: Are you ready to send your application?
     hint: Check your answers first.
@@ -26,6 +24,27 @@ en:
       </ul>
       <p class="govuk-body">There’s also guidance on <a href="https://www.gov.uk/coronavirus" class="govuk-link">what you need to do<a/>.</p>
       <p class="govuk-body">We won’t store the information you entered into this service.</p>
+  accessibility_statement:
+    title: Accessibility statement
+    body_text: |
+      <p class="govuk-body">This accessibility statement applies to the service on GOV.UK to get coronavirus support as an extremely vulnerable person.</p>
+      <p class="govuk-body">This website is run by the Government Digital Service. It is designed to be used by as many people as possible. The text should be clear and simple to understand. You should be able to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>zoom in up to 300% without problems</li>
+        <li>navigate most of the website using just a keyboard</li>
+        <li>navigate most of the website using speech recognition software</li>
+        <li>use most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+      </ul>
+      <h2 class="govuk-heading-m">Reporting accessibility problems with this website</h2>
+      <p class="govuk-body">We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, <a class="govuk-link" href="https://www.gov.uk/contact/govuk">contact us</a>.</p>
+      <h2 class="govuk-heading-m">Enforcement procedure</h2>
+      <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the <a class="govuk-link" href="https://www.equalityadvisoryservice.com/" rel="external">Equality Advisory and Support Service (EASS)</a>.</p>
+      <h2 class="govuk-heading-m">Technical information about this website’s accessibility</h2>
+      <p class="govuk-body">The Government Digital Service is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+      <p class="govuk-body">This website is fully compliant with the Web Content Accessibility Guidelines version 2.1 AA standard.</p>
+      <h2 class="govuk-heading-m">How we tested this website</h2>
+      <p class="govuk-body">This website was last tested on 27 March 2020. The test was carried out by the Government Digital Service, based on the <a class="govuk-link" href="https://design-system.service.gov.uk/accessibility/">accessibility statement for the GOV.UK Design System</a>.</p>
+      <p class="govuk-body">This statement was prepared on 27 March 2020. It was last updated on 27 March 2020.</p>
   privacy_page:
     title: Privacy
     body_text: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   scope module: "coronavirus_form" do
     get "/privacy", to: "privacy#show"
+    get "/accessibility-statement", to: "accessibility_statement#show"
 
     # (v4[sunday]) Question 1: Do you live in England?
     get "/live-in-england", to: "live_in_england#show"

--- a/spec/controllers/coronavirus_form/accessibility_statement_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/accessibility_statement_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::AccessibilityStatementController, type: :controller do
+  let(:current_template) { "coronavirus_form/accessibility_statement" }
+
+  describe "GET show" do
+    it "renders the page" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+end


### PR DESCRIPTION
## What

Add accessibility statement content and link to statement in the footer. Content from the ticket: https://trello.com/c/xnRaNRXL

Also removed label / title duplication in translation file for the footer links. The privacy policy has a label in one part of the translation file, and the title in another part of the file - both of which were the same.

## Why

The service needs a statement. 

## Visual changes

![image](https://user-images.githubusercontent.com/1732331/77906769-68ed8b80-7280-11ea-96de-625ce858b0c7.png)
