### PR TITLE
Don't prepend year with "00"

### DIFF
--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -33,7 +33,7 @@ module AnswersHelper
     elsif question.eql?("support_address")
       answer.values.compact.join(",<br>")
     elsif question.eql?("date_of_birth")
-      Time.zone.local(answer["year"], answer["month"], answer["day"]).strftime("%d/%m/%Y") if complete_date?(answer)
+      Time.zone.local(answer["year"], answer["month"], answer["day"]).strftime("%d/%m/%-Y") if complete_date?(answer)
     else
       answer.values.compact.join(" ")
     end

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -113,6 +113,17 @@ RSpec.describe AnswersHelper, type: :helper do
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
 
+      it "doesn't pad two character years" do
+        answer = {
+          "year" => "70",
+          "month" => "01",
+          "day" => "31",
+        }
+
+        expected_answer = "31/01/70"
+        expect(helper.concat_answer(answer, question)).to eq(expected_answer)
+      end
+
       it "returns nothing if the date_of_birth is empty" do
         answer = {}
 


### PR DESCRIPTION
Trello: https://trello.com/c/LSvX1GUl

# What's changed?
Stop prepending the year with "00" if the user enters a two character year for their date of birth

# Expected changes
## Before
![screenshot-govuk-coronavirus-vulnerable-people-form-stg cloudapps digital-2020 03 30-12_57_20](https://user-images.githubusercontent.com/5793815/77910111-773ea600-7286-11ea-9693-f66fa631780a.png)

## After
![screenshot-localhost_5000-2020 03 30-12_55_19](https://user-images.githubusercontent.com/5793815/77910100-73128880-7286-11ea-993c-be9834b20212.png)
