### PR TITLE
Improve logging of validation errors and requests

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/initializers/dynamoid.rb
+++ b/config/initializers/dynamoid.rb
@@ -8,6 +8,7 @@ Dynamoid.configure do |config|
   config.access_key = ENV["AWS_ACCESS_KEY_ID"]
   config.secret_key = ENV["AWS_SECRET_ACCESS_KEY"]
   config.region = "eu-west-2"
+  config.logger = ActiveSupport::Logger.new(STDOUT)
   config.logger.level = :error
 
   unless Rails.env.production?

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[password email name first_name middle_name last_name nhs_number nhs_letter date_of_birth carry_supplies live_in_england phone_number_calls phone_number_texts know_nhs_number basic_care_needs essential_supplies medical_conditions dietary_requirements building_and_street_line_1 building_and_street_line_2 town_city county postcode]


### PR DESCRIPTION
closes: #172 
Trello: https://trello.com/c/CpNKGtCb/71-ensure-sensitive-data-doesnt-go-to-logit-splunk

We currently have a logging level set to error, as we wanted to prevent accidentally logging PII information (which can be seen in request and Dynamoid logs). However, this has prevented us from capturing information about which validation errors users are experience as they are logged at an info level. This PR increases the logging level of the default Rails logger to info, but suppresses PII data by:
- Dynamoid uses a separate logger at a lower level (error)
- Parameter filter to mask user data with in requests.