### PR TITLE
Use asset sync to store compiled assets in S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,10 @@ source "https://rubygems.org"
 
 gem "rails", "~> 6.0.2"
 
+gem "asset_sync"
 gem "bootsnap", "~> 1"
 gem "dynamoid"
+gem "fog-aws"
 gem "govuk_app_config", "~> 2.1.1"
 gem "govuk_publishing_components", "~> 21.31.0"
 gem "log_formatter", "~> 0.8.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,11 @@ GEM
     apparition (0.5.0)
       capybara (~> 3.13, < 4)
       websocket-driver (>= 0.6.5)
+    asset_sync (2.11.0)
+      activemodel (>= 4.1.0)
+      fog-core
+      mime-types (>= 2.99)
+      unf
     ast (2.4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
@@ -124,11 +129,29 @@ GEM
       concurrent-ruby (>= 1.0)
       null-logger
     erubi (1.9.0)
+    excon (0.73.0)
     execjs (2.7.0)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
+    fog-aws (3.6.2)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.0)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     foreman (0.87.0)
+    formatador (0.2.5)
     gds-api-adapters (63.5.1)
       addressable
       link_header
@@ -160,6 +183,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    ipaddress (0.8.3)
     jaro_winkler (1.5.4)
     jmespath (1.4.0)
     kgio (2.11.3)
@@ -364,6 +388,7 @@ PLATFORMS
 
 DEPENDENCIES
   apparition (~> 0.5.0)
+  asset_sync
   awesome_print (~> 1.8)
   bootsnap (~> 1)
   byebug (~> 11)
@@ -371,6 +396,7 @@ DEPENDENCIES
   cucumber (~> 3.1.2)
   cucumber-rails (~> 2.0)
   dynamoid
+  fog-aws
   foreman (~> 0.87.0)
   govuk_app_config (~> 2.1.1)
   govuk_publishing_components (~> 21.31.0)

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -83,6 +83,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((aws-secret-access-key))
           SECRET_KEY_BASE: ((secret-key-base-staging))
           AWS_DYNAMODB_SUBMISSIONS_TABLE_NAME: coronavirus-vulnerable-people-staging
+          AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-vulnerable-people-assets-staging
           HOSTNAME: govuk-coronavirus-vulnerable-people-form-stg
 
   - name: smoke-test-staging
@@ -131,6 +132,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ((aws-secret-access-key-prod))
           SECRET_KEY_BASE: ((secret-key-base-prod))
           AWS_DYNAMODB_SUBMISSIONS_TABLE_NAME: coronavirus-vulnerable-people-prod
+          AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-vulnerable-people-assets-prod
           HOSTNAME: govuk-coronavirus-vulnerable-people-form-prod
 
   - name: smoke-test-prod

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -39,6 +39,7 @@ run:
       cf scale -i "$INSTANCES" govuk-coronavirus-vulnerable-people-form
 
       cf set-env govuk-coronavirus-vulnerable-people-form AWS_DYNAMODB_SUBMISSIONS_TABLE_NAME "$AWS_DYNAMODB_SUBMISSIONS_TABLE_NAME"
+      cf set-env govuk-coronavirus-vulnerable-people-form AWS_ASSETS_BUCKET_NAME "$AWS_ASSETS_BUCKET_NAME"
       if [[ "${REQUIRE_BASIC_AUTH:-}" = "true" ]]; then
         cf set-env govuk-coronavirus-vulnerable-people-form REQUIRE_BASIC_AUTH "$REQUIRE_BASIC_AUTH"
       fi

--- a/config/initializers/asset_sync.rb
+++ b/config/initializers/asset_sync.rb
@@ -1,0 +1,12 @@
+if defined?(AssetSync)
+  AssetSync.configure do |config|
+    config.fog_provider = "AWS"
+    config.fog_region = "eu-west-2"
+    config.fog_directory = ENV["AWS_ASSETS_BUCKET_NAME"]
+    config.aws_access_key_id = ENV["AWS_ACCESS_KEY_ID"]
+    config.aws_secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
+
+    # Don't delete files from the store
+    config.existing_remote_files = "keep"
+  end
+end


### PR DESCRIPTION
When we do a new release, we replace one instance at a time until we've replaced all the instances.

This means there's an old and a new version of the app running at the same time.

The new version of the app may decide that the assets are served from a different filename so it will render `<link>` tags with that filename. When the user's browser requests that URL, it might get load balanced to an application that doesn't know about the new file yet, resulting in a 404.

To overcome this we can store the assets in a S3 bucket and use that as our cloud front origin. This PR add the `asset-sync` gem to handle uploading assets to S3 and set the require environment variable in concourse.