### PR TITLE
Only include GOV.UK Frontend JavaScript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,2 @@
-//= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/all_components
+// = require govuk/all.js
+window.GOVUKFrontend.initAll()


### PR DESCRIPTION
## What

The only JavaScript used by this app focuses the error summary when a form field has been filled in incorrectly. We're currently including all of the JavaScript from GOV.UK Publishing Components.

To reduce the size of the JavaScript, we only include the JavaScript from GOV.UK Frontend. This is a sneaky steal from https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/161 (Thanks!)

Ticket: https://trello.com/c/AgOY16P1

Before: 669.0 KB unminfied, 235.2 KB minified

After: 81.8 KB unmagnified, 32.2 KB minified


## Why

Less JavaScript == faster website.

## Visual differences

None.