### PR TITLE
Restringify some keys

### DIFF
--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -26,14 +26,14 @@ module AnswersHelper
 
     if question.eql?("contact_details")
       concatenated_answer = []
-      concatenated_answer << "Phone number: #{answer[:phone_number_calls]}" if answer[:phone_number_calls]
-      concatenated_answer << "Text: #{answer[:phone_number_texts]}" if answer[:phone_number_texts]
-      concatenated_answer << "Email: #{answer[:email]}" if answer[:email]
+      concatenated_answer << "Phone number: #{answer['phone_number_calls']}" if answer["phone_number_calls"]
+      concatenated_answer << "Text: #{answer['phone_number_texts']}" if answer["phone_number_texts"]
+      concatenated_answer << "Email: #{answer['email']}" if answer["email"]
       concatenated_answer.join("<br>")
     elsif question.eql?("support_address")
       answer.values.compact.join(",<br>")
     elsif question.eql?("date_of_birth")
-      Time.zone.local(answer[:year], answer[:month], answer[:day]).strftime("%d/%m/%-Y") if complete_date?(answer)
+      Time.zone.local(answer["year"], answer["month"], answer["day"]).strftime("%d/%m/%-Y") if complete_date?(answer)
     else
       answer.values.compact.join(" ")
     end
@@ -41,7 +41,7 @@ module AnswersHelper
 
   def complete_date?(date)
     date.present? &&
-      %i(day month year).all? { |required_key| date.key?(required_key) } &&
+      %w(day month year).all? { |required_key| date.key?(required_key) } &&
       date.values.all?(&:present?)
   end
 

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -31,7 +31,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_calls.label"),
   },
-  value: session.dig(:contact_details, :phone_number_calls),
+  value: session.dig(:contact_details, "phone_number_calls"),
   error_message: error_items("phone_number_calls"),
   width: 20,
   type: "tel",
@@ -43,7 +43,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_texts.label"),
   },
-  value: session.dig(:contact_details, :phone_number_texts),
+  value: session.dig(:contact_details, "phone_number_texts"),
   error_message: error_items("phone_number_texts"),
   width: 20,
   type: "tel",
@@ -56,7 +56,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.email.label"),
   },
-  value: session.dig(:contact_details, :email),
+  value: session.dig(:contact_details, "email"),
   error_message: error_items("email"),
   type: "email",
   autocomplete: "email",

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -30,7 +30,7 @@
       id: "date_of_birth-day",
       name: "day",
       width: 2,
-      value: session.dig(:date_of_birth, :day),
+      value: session.dig(:date_of_birth, "day"),
       autocomplete: "bday-day",
     },
     {
@@ -38,7 +38,7 @@
       id: "date_of_birth-month",
       name: "month",
       width: 2,
-      value: session.dig(:date_of_birth, :month),
+      value: session.dig(:date_of_birth, "month"),
       autocomplete: "bday-month",
     },
     {
@@ -46,7 +46,7 @@
       id: "date_of_birth-year",
       name: "year",
       width: 4,
-      value: session.dig(:date_of_birth, :year),
+      value: session.dig(:date_of_birth, "year"),
       autocomplete: "bday-year",
     }
   ]

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -33,7 +33,7 @@
   id: "first_name",
   name: "first_name",
   error_message: error_items("first_name"),
-  value: session.dig(:name, :first_name),
+  value: session.dig(:name, "first_name"),
   autocomplete: "given-name",
 } %>
 
@@ -44,7 +44,7 @@
   id: "middle_name",
   name: "middle_name",
   error_message: error_items("middle_name"),
-  value: session.dig(:name, :middle_name),
+  value: session.dig(:name, "middle_name"),
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -54,7 +54,7 @@
   id: "last_name",
   name: "last_name",
   error_message: error_items("last_name"),
-  value: session.dig(:name, :last_name),
+  value: session.dig(:name, "last_name"),
   autocomplete: "family-name",
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -33,7 +33,7 @@
   name: "building_and_street_line_1",
   type: "text",
   error_message: error_items('building_and_street_line_1'),
-  value: session.dig(:support_address, :building_and_street_line_1),
+  value: session.dig(:support_address, "building_and_street_line_1"),
   autocomplete: "address-line1",
 } %>
 
@@ -44,7 +44,7 @@
   id: "building_and_street_line_2",
   name: "building_and_street_line_2",
   error_message: error_items('building_and_street_line_2'),
-  value: session.dig(:support_address, :building_and_street_line_2),
+  value: session.dig(:support_address, "building_and_street_line_2"),
   autocomplete: "address-line2",
 } %>
 
@@ -56,7 +56,7 @@
   name: "town_city",
   type: "text",
   error_message: error_items('town_city'),
-  value: session.dig(:support_addres, :town_city),
+  value: session.dig(:support_address, "town_city"),
   width: 20,
   autocomplete: "address-level2",
 } %>
@@ -69,7 +69,7 @@
   name: "county",
   type: "text",
   error_message: error_items('county'),
-  value: session.dig(:support_address, :county),
+  value: session.dig(:support_address, "county"),
   width: 20,
 } %>
 
@@ -81,7 +81,7 @@
   name: "postcode",
   type: "text",
   error_message: error_items('postcode'),
-  value: session.dig(:support_address, :postcode),
+  value: session.dig(:support_address, "postcode"),
   width: 10,
   autocomplete: "postal-code",
 } %>

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "concatenates contact_details with a line break" do
         answer = {
-          phone_number_calls: "012101234567",
-          phone_number_texts: "0777001234567",
-          email: "me@example.com",
+          "phone_number_calls" => "012101234567",
+          "phone_number_texts" => "0777001234567",
+          "email" => "me@example.com",
         }
 
         expected_answer =
-          "Phone number: #{answer[:phone_number_calls]}<br>Text: #{answer[:phone_number_texts]}<br>Email: #{answer[:email]}"
+          "Phone number: #{answer['phone_number_calls']}<br>Text: #{answer['phone_number_texts']}<br>Email: #{answer['email']}"
 
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
@@ -55,10 +55,10 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "only concatenates the fields that have a value" do
         answer = {
-          email: "me@example.com",
+          "email" => "me@example.com",
         }
 
-        expected_answer = "Email: #{answer[:email]}"
+        expected_answer = "Email: #{answer['email']}"
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
     end
@@ -104,9 +104,9 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "concatenates date_of_birth as dd/mm/yyyy" do
         answer = {
-          year: "1970",
-          month: "01",
-          day: "31",
+          "year" => "1970",
+          "month" => "01",
+          "day" => "31",
         }
 
         expected_answer = "31/01/1970"
@@ -115,9 +115,9 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "doesn't pad two character years" do
         answer = {
-          year: "70",
-          month: "01",
-          day: "31",
+          "year" => "70",
+          "month" => "01",
+          "day" => "31",
         }
 
         expected_answer = "31/01/70"
@@ -132,8 +132,8 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "returns nothing if part of the date is missing" do
         answer = {
-          month: "01",
-          day: "31",
+          "month" => "01",
+          "day" => "31",
         }
 
         expect(helper.concat_answer(answer, question)).to be_nil
@@ -141,9 +141,9 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "returns nothing if the date is nil" do
         answer = {
-          month: nil,
-          day: nil,
-          year: nil,
+          "year" => nil,
+          "month" => nil,
+          "day" => nil,
         }
 
         expect(helper.concat_answer(answer, question)).to be_nil
@@ -155,9 +155,9 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "concates other hash questions" do
         answer = {
-          one: "One",
-          two: "Two",
-          three: "Three",
+          "one" => "One",
+          "two" => "Two",
+          "three" => "Three",
         }
 
         expected_answer = "One Two Three"


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/149

Rails unhelpfully stringifies some keys in the session:
https://github.com/rails/rails/blob/ea4f0e2baba8653b03fba154357842933cf7b778/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb#L97

Which means that our views weren't able to access the values.

This only seems to affect nested keys.