### PR TITLE
concourse: Make the pipeline update itself

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -52,6 +52,13 @@ resources:
       tag: govuk-coronavirus-vulnerable-people-form-feature-tests
 
 jobs:
+  - name: update-pipeline
+    plan:
+      - get: govuk-coronavirus-vulnerable-people-form
+        trigger: true
+      - set-pipeline: govuk-corona-vulnerable-people-form
+        file: govuk-coronavirus-vulnerable-people-form/concourse/pipeline.yml
+
   - name: build-feature-tests-image
     serial: true
     plan:


### PR DESCRIPTION
- It's time consuming to remember all the parameters to set this pipeline (`fly -t cd-govuk-tools set-pipeline -c concourse/pipeline.yml -p govuk-corona-vulnerable-people-form`) when we make changes.
- Given we're iterating at such speed, we can save ourselves the hassle by using Concourse's (beta, but in use across GDS) [self-updating pipeline](https://concourse-ci.org/jobs.html#set-pipeline-step) mechanism.

https://trello.com/c/Ys6zxUC4/62-get-concourse-to-auto-deploy-the-pipeline