### PR TITLE
Remove smoke test checking CSS path doesn't change

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -103,19 +103,6 @@ jobs:
         params:
           URL: 'https://govuk-coronavirus-vulnerable-people-form-stg.cloudapps.digital/live-in-england'
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
-      - task: smoke-test-css
-        file: govuk-coronavirus-vulnerable-people-form/concourse/tasks/smoke-test.yml
-        params:
-          URL: 'https://govuk-coronavirus-vulnerable-people-form-stg.cloudapps.digital/assets/application-625e5a1280b6f7c5d39998a22c0d9a4339fde989a41584d7765dd2f291a148ba.css'
-          MESSAGE: |
-            This smoke test is here to check that the CSS file name does not change from the version we're currently using in production.
-
-            Deploying a change to the CSS would currently cause 404s on the CSS during the rolling deployment to production. This would cause users to see an unstyled version of the form.
-
-            See this trello card for more details - https://trello.com/c/cfGnjdZV/175-fix-issues-with-assets-404ing-during-rolling-deployments
-
-            If you urgently need to deploy a CSS change, and you can accept a few minutes of unstyled pages being served to users, you can disable this task with /fly set-pipeline/
-
       - task: run-cucumber-specs
         file: govuk-coronavirus-vulnerable-people-form/concourse/tasks/run-cucumber-specs.yml
         params:


### PR DESCRIPTION
In https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/208
we made the application sync it's assets with S3 when it stages. In
https://github.com/alphagov/tech-ops-private/pull/252 we started serving
assets from the S3 bucket instead of rails.

This means we no longer have the problem with assets 404ing during
rolling deployments, so we no longer need this check.