### PR TITLE
Change validation logging to be json

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,11 @@ private
   end
 
   def log_validation_error(invalid_fields)
-    logger.info "validation error - #{invalid_fields.pluck(:text).to_sentence}"
+    logger.info do
+      {
+        validation_error: { text: invalid_fields.pluck(:text).to_sentence },
+      }.to_json
+    end
   end
 
   def session_expired


### PR DESCRIPTION
## What
Turns validation logs from strings to JSON.

## Why
Your might remember this change from [PRs such as this one](https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/168). It's a good idea for these apps to be in parity.