### PR TITLE
Set config.hosts for all environments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,7 @@ inherit_mode:
 Metrics/BlockLength:
   Exclude:
     - config/**/*
+
+Style/WordArray:
+  Exclude:
+    - config/**/*.rb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,6 +4,10 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in
   # config/application.rb.
 
+  config.hosts = [
+    "localhost",
+  ]
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,6 +4,13 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in
   # config/application.rb.
 
+  config.hosts = [
+    "coronavirus-vulnerable-people.service.gov.uk",
+    "d18j9d8kwes7fb.cloudfront.net",
+    "govuk-coronavirus-vulnerable-people-form-prod.cloudapps.digital",
+    "govuk-coronavirus-vulnerable-people-form-stg.cloudapps.digital",
+  ]
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
If a user sets an X-Forwarded header in a request, this will in some cases override the Host header in a Rails app, resulting in URL redirection to a different website. If an attacker manages to poison a cache with such a header, users will be redirected to malicious sites.

In https://github.com/rails/rails/issues/29893, the resolution is to set config.hosts.  Therefore setting this for all environments in this app.

Trello card: https://trello.com/c/vdSUBzGw