### PR TITLE
Make postcode mandatory

### DIFF
--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -4,6 +4,7 @@ class CoronavirusForm::SupportAddressController < ApplicationController
   REQUIRED_FIELDS = %i[
       building_and_street_line_1
       town_city
+      postcode
   ].freeze
 
   def submit
@@ -35,29 +36,8 @@ private
   def validate_fields(support_address)
     [
       validate_missing_fields(support_address),
-      validate_conditionally_present_fields(support_address),
       validate_postcode("postcode", support_address.dig(:postcode)),
     ].flatten.uniq
-  end
-
-  def validate_conditionally_present_fields(product)
-    return [] if product.dig(:postcode).present? || product.dig(:county).present?
-
-    invalid_fields = []
-
-    if product.dig(:county).blank?
-      invalid_fields << {
-        field: "county",
-        text: t("coronavirus_form.errors.missing_county_or_postcode_field"),
-      }
-    elsif product.dig(:postcode).blank?
-      invalid_fields << {
-        field: "postcode",
-        text: t("coronavirus_form.errors.missing_county_or_postcode_field"),
-      }
-    end
-
-    invalid_fields
   end
 
   def validate_missing_fields(product)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,6 @@ en:
       radio_field: "Select %{field}"
       checkbox_field: "Select at least one %{field}"
       missing_mandatory_text_field: "Enter %{field}"
-      missing_county_or_postcode_field: "Enter either a postcode or a county"
       invalid_money: "%{field} must be an amount of money, like 15000"
       missing_date: "Enter your date of birth"
       missing_fields: "Enter your date of birth and include a day, month and year"

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -83,17 +83,6 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       expect(response).to redirect_to(next_page)
     end
 
-    it "redirects to next page when provided address line 1, town and county" do
-      post :submit, params: params.except("building_and_street_line_2", "postcode")
-
-      expect(session[session_key]).to eq address.merge({
-        building_and_street_line_2: nil,
-        postcode: nil,
-        })
-
-      expect(response).to redirect_to(next_page)
-    end
-
     it "redirects to next step when all fields are provided" do
       post :submit, params: params
 


### PR DESCRIPTION
Currently we require postcode OR county to be provided.

This change will mean we always require postcode, and do not require county.

Postcode is a much more useful field; we need to know a person's postcode in order to deliver food to them.

https://trello.com/c/ThWRWPtw/113-make-postcode-mandatory