### PR TITLE
Update NHS number page to match prototype

### DIFF
--- a/app/views/coronavirus_form/nhs_number.html.erb
+++ b/app/views/coronavirus_form/nhs_number.html.erb
@@ -15,30 +15,19 @@
       "novalidate": "true"
     ) do %>
 
-    <%= render "govuk_publishing_components/components/title", {
-      title: t('coronavirus_form.questions.nhs_number.title'),
-      margin_top: 0,
-      margin_bottom: 3,
-    } %>
-
-    <%= render "govuk_publishing_components/components/hint", {
-      text: t('coronavirus_form.questions.nhs_number.hint_format'),
-    } %>
-
-    <%= render "govuk_publishing_components/components/hint", {
-      text: t('coronavirus_form.questions.nhs_number.hint_where_to_find'),
-    } %>
-
     <%= render "govuk_publishing_components/components/input", {
       "id": "nhs_number",
       name: "nhs_number",
       label: {
-        text: t('coronavirus_form.questions.nhs_number.nhs_number.label'),
+        text: t("coronavirus_form.questions.nhs_number.title"),
+        is_page_heading: true,
       },
+      heading_size: "xl",
+      hint: sanitize(t("coronavirus_form.questions.nhs_number.hint")),
       type: "number",
       error_message: error_items('nhs_number'),
       value: session[:nhs_number],
-      width: 20,
+      width: 10,
     } %>
 
     <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -269,10 +269,11 @@ en:
         custom_select_error: Select yes if you know your NHS number
       nhs_number:
         title: What is your NHS number?
-        hint_format: An NHS Number is a 10 digit number, like 485 777 3456.
-        hint_where_to_find: You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service.
+        hint: |
+          An NHS Number is a 10 digit number, like 485 777 3456.
+          <br /><br />
+          You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service.
         nhs_number:
-          label: NHS Number
           custom_errors:
             missing: Enter your 10-digit NHS number
             must_be_a_number: NHS number must be a number


### PR DESCRIPTION
Makes two changes that are present in the prototype but not the app:
- Removes the label for the input field
- Reduces width of the input field

Maintains the relationship of a label against the input field for accessibility reasons.

Before change:
<img width="1010" alt="Screenshot 2020-04-03 at 16 13 02" src="https://user-images.githubusercontent.com/6329861/78376309-0967e680-75c6-11ea-87ea-a749a95f175b.png">

After change:
<img width="994" alt="Screenshot 2020-04-03 at 16 12 35" src="https://user-images.githubusercontent.com/6329861/78376324-0ec53100-75c6-11ea-9138-a2588f61f7c2.png">
