### PR TITLE
Perform validations before setting session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :check_first_question, only: [:show]
 
   def show
+    @form_responses = session.to_hash.with_indifferent_access
     respond_to do |format|
       format.html { render controller_path }
     end

--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -2,12 +2,13 @@
 
 class CoronavirusForm::BasicCareNeedsController < ApplicationController
   def submit
-    basic_care_needs = strip_tags(params[:basic_care_needs]).presence
-    session[:basic_care_needs] = basic_care_needs
+    @form_responses = {
+      basic_care_needs: strip_tags(params[:basic_care_needs]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: basic_care_needs,
+      radio: @form_responses[:basic_care_needs],
     )
 
     if invalid_fields.any?
@@ -18,8 +19,10 @@ class CoronavirusForm::BasicCareNeedsController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
+      session[:basic_care_needs] = @form_responses[:basic_care_needs]
       redirect_to check_your_answers_url
     else
+      session[:basic_care_needs] = @form_responses[:basic_care_needs]
       redirect_to dietary_requirements_url
     end
   end

--- a/app/controllers/coronavirus_form/carry_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/carry_supplies_controller.rb
@@ -2,12 +2,13 @@
 
 class CoronavirusForm::CarrySuppliesController < ApplicationController
   def submit
-    carry_supplies = strip_tags(params[:carry_supplies]).presence
-    session[:carry_supplies] = carry_supplies
+    @form_responses = {
+      carry_supplies: strip_tags(params[:carry_supplies]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: carry_supplies,
+      radio: @form_responses[:carry_supplies],
     )
 
     if invalid_fields.any?
@@ -18,6 +19,7 @@ class CoronavirusForm::CarrySuppliesController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     else
+      session[:carry_supplies] = @form_responses[:carry_supplies]
       redirect_to check_your_answers_url
     end
   end

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -2,15 +2,16 @@
 
 class CoronavirusForm::ContactDetailsController < ApplicationController
   def submit
-    contact_details = {
-      phone_number_calls: strip_tags(params[:phone_number_calls]&.strip).presence,
-      phone_number_texts: strip_tags(params[:phone_number_texts]&.strip).presence,
-      email: strip_tags(params[:email]&.strip).presence,
+    @form_responses = {
+      contact_details: {
+        phone_number_calls: strip_tags(params[:phone_number_calls]&.strip).presence,
+        phone_number_texts: strip_tags(params[:phone_number_texts]&.strip).presence,
+        email: strip_tags(params[:email]&.strip).presence,
+      },
     }
-    session[:contact_details] = contact_details
 
-    invalid_fields = if session[:contact_details].dig(:email)
-                       validate_email_address("email", session[:contact_details].dig(:email))
+    invalid_fields = if @form_responses[:contact_details].dig(:email)
+                       validate_email_address("email", @form_responses.dig(:contact_details, :email))
                      else
                        []
                      end
@@ -23,8 +24,10 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
+      session[:contact_details] = @form_responses[:contact_details]
       redirect_to check_your_answers_url
     else
+      session[:contact_details] = @form_responses[:contact_details]
       redirect_to know_nhs_number_url
     end
   end

--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -2,15 +2,18 @@
 
 class CoronavirusForm::DateOfBirthController < ApplicationController
   def submit
-    session[:date_of_birth] ||= {}
-    session[:date_of_birth][:day] = strip_tags(params.dig(:date_of_birth, :day)&.strip).presence
-    session[:date_of_birth][:month] = strip_tags(params.dig(:date_of_birth, :month)&.strip).presence
-    session[:date_of_birth][:year] = strip_tags(params.dig(:date_of_birth, :year)&.strip).presence
+    @form_responses = {
+      date_of_birth: {
+        day: strip_tags(params.dig(:date_of_birth, :day)&.strip).presence,
+        month: strip_tags(params.dig(:date_of_birth, :month)&.strip).presence,
+        year: strip_tags(params.dig(:date_of_birth, :year)&.strip).presence,
+      },
+    }
 
     invalid_fields = validate_date_of_birth(
-      session[:date_of_birth].dig(:year),
-      session[:date_of_birth].dig(:month),
-      session[:date_of_birth].dig(:day),
+      @form_responses[:date_of_birth].dig(:year),
+      @form_responses[:date_of_birth].dig(:month),
+      @form_responses[:date_of_birth].dig(:day),
       "date_of_birth",
     )
 
@@ -22,8 +25,10 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
+      session[:date_of_birth] = @form_responses[:date_of_birth]
       redirect_to check_your_answers_url
     else
+      session[:date_of_birth] = @form_responses[:date_of_birth]
       redirect_to support_address_url
     end
   end

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -2,12 +2,13 @@
 
 class CoronavirusForm::DietaryRequirementsController < ApplicationController
   def submit
-    dietary_requirements = strip_tags(params[:dietary_requirements]).presence
-    session[:dietary_requirements] = dietary_requirements
+    @form_responses = {
+      dietary_requirements: strip_tags(params[:dietary_requirements]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: dietary_requirements,
+      radio: @form_responses[:dietary_requirements],
     )
 
     if invalid_fields.any?
@@ -18,8 +19,10 @@ class CoronavirusForm::DietaryRequirementsController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
+      session[:dietary_requirements] = @form_responses[:dietary_requirements]
       redirect_to check_your_answers_url
     else
+      session[:dietary_requirements] = @form_responses[:dietary_requirements]
       redirect_to carry_supplies_url
     end
   end

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -2,12 +2,13 @@
 
 class CoronavirusForm::EssentialSuppliesController < ApplicationController
   def submit
-    essential_supplies = strip_tags(params[:essential_supplies]).presence
-    session[:essential_supplies] = essential_supplies
+    @form_responses = {
+      essential_supplies: strip_tags(params[:essential_supplies]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: essential_supplies,
+      radio: @form_responses[:essential_supplies],
     )
 
     if invalid_fields.any?
@@ -18,8 +19,10 @@ class CoronavirusForm::EssentialSuppliesController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
+      session[:essential_supplies] = @form_responses[:essential_supplies]
       redirect_to check_your_answers_url
     else
+      session[:essential_supplies] = @form_responses[:essential_supplies]
       redirect_to basic_care_needs_url
     end
   end

--- a/app/controllers/coronavirus_form/know_nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/know_nhs_number_controller.rb
@@ -2,14 +2,13 @@
 
 class CoronavirusForm::KnowNhsNumberController < ApplicationController
   def submit
-    know_nhs_number = strip_tags(params[:know_nhs_number]).presence
-    session[:know_nhs_number] = know_nhs_number
-
-    session[:nhs_number] = nil if I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
+    @form_responses = {
+      know_nhs_number: strip_tags(params[:know_nhs_number]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: know_nhs_number,
+      radio: @form_responses[:know_nhs_number],
     )
 
     if invalid_fields.any?
@@ -19,16 +18,24 @@ class CoronavirusForm::KnowNhsNumberController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label")
+    elsif @form_responses[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_yes.label")
+      set_session_values
       redirect_to nhs_number_url
     elsif session[:check_answers_seen]
+      set_session_values
       redirect_to check_your_answers_url
-    elsif session[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
+    elsif @form_responses[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
+      set_session_values
       redirect_to essential_supplies_url
     end
   end
 
 private
+
+  def set_session_values
+    session[:know_nhs_number] = @form_responses[:know_nhs_number]
+    session[:nhs_number] = nil if @form_responses[:know_nhs_number] == I18n.t("coronavirus_form.questions.know_nhs_number.options.option_no.label")
+  end
 
   def previous_path
     contact_details_path

--- a/app/controllers/coronavirus_form/live_in_england_controller.rb
+++ b/app/controllers/coronavirus_form/live_in_england_controller.rb
@@ -4,12 +4,13 @@ class CoronavirusForm::LiveInEnglandController < ApplicationController
   skip_before_action :check_first_question
 
   def submit
-    live_in_england = strip_tags(params[:live_in_england]).presence
-    session[:live_in_england] = live_in_england
+    @form_responses = {
+    live_in_england: strip_tags(params[:live_in_england]).presence,
+  }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: live_in_england,
+      radio: @form_responses[:live_in_england],
     )
 
     if invalid_fields.any?
@@ -19,11 +20,14 @@ class CoronavirusForm::LiveInEnglandController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session[:live_in_england] == I18n.t("coronavirus_form.questions.live_in_england.options.option_no.label")
+    elsif @form_responses[:live_in_england] == I18n.t("coronavirus_form.questions.live_in_england.options.option_no.label")
+      session[:live_in_england] = @form_responses[:live_in_england]
       redirect_to not_eligible_england_url
     elsif session[:check_answers_seen]
+      session[:live_in_england] = @form_responses[:live_in_england]
       redirect_to check_your_answers_url
     else
+      session[:live_in_england] = @form_responses[:live_in_england]
       redirect_to nhs_letter_url
     end
   end

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -2,12 +2,13 @@
 
 class CoronavirusForm::MedicalConditionsController < ApplicationController
   def submit
-    medical_conditions = strip_tags(params[:medical_conditions]).presence
-    session[:medical_conditions] = medical_conditions
+    @form_responses = {
+    medical_conditions: strip_tags(params[:medical_conditions]).presence,
+  }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: medical_conditions,
+      radio: @form_responses[:medical_conditions],
     )
 
     if invalid_fields.any?
@@ -17,11 +18,14 @@ class CoronavirusForm::MedicalConditionsController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session[:medical_conditions] == I18n.t("coronavirus_form.questions.medical_conditions.options.option_no.label")
+    elsif @form_responses[:medical_conditions] == I18n.t("coronavirus_form.questions.medical_conditions.options.option_no.label")
+      session[:medical_conditions] = @form_responses[:medical_conditions]
       redirect_to not_eligible_medical_url
     elsif session[:check_answers_seen]
+      session[:medical_conditions] = @form_responses[:medical_conditions]
       redirect_to check_your_answers_url
     else
+      session[:medical_conditions] = @form_responses[:medical_conditions]
       redirect_to name_url
     end
   end

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -2,10 +2,13 @@
 
 class CoronavirusForm::NameController < ApplicationController
   def submit
-    session[:name] ||= {}
-    session[:name][:first_name] = strip_tags(params[:first_name]&.strip).presence
-    session[:name][:middle_name] = strip_tags(params[:middle_name]&.strip).presence
-    session[:name][:last_name] = strip_tags(params[:last_name]&.strip).presence
+    @form_responses = {
+      name: {
+        first_name: strip_tags(params[:first_name]&.strip).presence,
+        middle_name: strip_tags(params[:middle_name]&.strip).presence,
+        last_name: strip_tags(params[:last_name]&.strip).presence,
+      },
+    }
 
     invalid_fields = validate_text_fields(%i[first_name last_name], controller_name)
 
@@ -17,8 +20,10 @@ class CoronavirusForm::NameController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
+      session[:name] = @form_responses[:name]
       redirect_to check_your_answers_url
     else
+      session[:name] = @form_responses[:name]
       redirect_to date_of_birth_url
     end
   end
@@ -27,7 +32,7 @@ private
 
   def validate_text_fields(mandatory_fields, page)
     mandatory_fields.each_with_object([]) do |field, invalid_fields|
-      next if session[:name].dig(field).present?
+      next if @form_responses[:name].dig(field).present?
 
       invalid_fields << { field: field.to_s,
                           text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -2,12 +2,13 @@
 
 class CoronavirusForm::NhsLetterController < ApplicationController
   def submit
-    nhs_letter = strip_tags(params[:nhs_letter]).presence
-    session[:nhs_letter] = nhs_letter
+    @form_responses = {
+      nhs_letter: strip_tags(params[:nhs_letter]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: nhs_letter,
+      radio: @form_responses[:nhs_letter],
     )
 
     if invalid_fields.any?
@@ -18,8 +19,10 @@ class CoronavirusForm::NhsLetterController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
+      session[:nhs_letter] = @form_responses[:nhs_letter]
       redirect_to check_your_answers_url
     else
+      session[:nhs_letter] = @form_responses[:nhs_letter]
       redirect_to medical_conditions_url
     end
   end

--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -4,10 +4,11 @@ class CoronavirusForm::NhsNumberController < ApplicationController
   include NhsNumberValidatorHelper
 
   def submit
-    session[:nhs_number] ||= ""
-    session[:nhs_number] = strip_tags(clean_nhs_number(params[:nhs_number])).presence
+    @form_responses = {
+      nhs_number: strip_tags(clean_nhs_number(params[:nhs_number])).presence,
+    }
 
-    invalid_fields = validate_fields(session[:nhs_number])
+    invalid_fields = validate_fields(@form_responses[:nhs_number])
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
@@ -17,8 +18,10 @@ class CoronavirusForm::NhsNumberController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
+      session[:nhs_number] = @form_responses[:nhs_number]
       redirect_to check_your_answers_url
     else
+      session[:nhs_number] = @form_responses[:nhs_number]
       redirect_to essential_supplies_url
     end
   end

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module FieldValidationHelper
-  def validate_mandatory_text_fields(mandatory_fields, page)
+  def validate_mandatory_text_fields(mandatory_fields, page, form_responses)
     invalid_fields = []
     mandatory_fields.each do |field|
-      next if session[field].present?
+      next if form_responses[field].present?
 
       invalid_fields << { field: field.to_s,
                           text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",

--- a/app/views/coronavirus_form/basic_care_needs.erb
+++ b/app/views/coronavirus_form/basic_care_needs.erb
@@ -25,7 +25,7 @@
       id: ("basic_care_needs" if index == 0),
       value: item[:label],
       text: item[:label],
-      checked: session[:basic_care_needs] == item[:label],
+      checked: @form_responses[:basic_care_needs] == item[:label],
     }
   end
 } %>

--- a/app/views/coronavirus_form/carry_supplies.html.erb
+++ b/app/views/coronavirus_form/carry_supplies.html.erb
@@ -26,7 +26,7 @@
           id: ("carry_supplies" if index == 0),
           value: item[:label],
           text: item[:label],
-          checked: session[:carry_supplies] == item[:label],
+          checked: @form_responses[:carry_supplies] == item[:label],
         }
       end
     } %>

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -31,7 +31,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_calls.label"),
   },
-  value: session.dig(:contact_details, "phone_number_calls"),
+  value: @form_responses.dig(:contact_details, :phone_number_calls),
   error_message: error_items("phone_number_calls"),
   width: 20,
   type: "tel",
@@ -43,7 +43,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.phone_number_texts.label"),
   },
-  value: session.dig(:contact_details, "phone_number_texts"),
+  value: @form_responses.dig(:contact_details, :phone_number_texts),
   error_message: error_items("phone_number_texts"),
   width: 20,
   type: "tel",
@@ -56,7 +56,7 @@
   label: {
     text: t("coronavirus_form.questions.contact_details.email.label"),
   },
-  value: session.dig(:contact_details, "email"),
+  value: @form_responses.dig(:contact_details, :email),
   error_message: error_items("email"),
   type: "email",
   autocomplete: "email",

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -30,7 +30,7 @@
       id: "date_of_birth-day",
       name: "day",
       width: 2,
-      value: session.dig(:date_of_birth, "day"),
+      value: @form_responses.dig(:date_of_birth, :day),
       autocomplete: "bday-day",
     },
     {
@@ -38,7 +38,7 @@
       id: "date_of_birth-month",
       name: "month",
       width: 2,
-      value: session.dig(:date_of_birth, "month"),
+      value: @form_responses.dig(:date_of_birth, :month),
       autocomplete: "bday-month",
     },
     {
@@ -46,7 +46,7 @@
       id: "date_of_birth-year",
       name: "year",
       width: 4,
-      value: session.dig(:date_of_birth, "year"),
+      value: @form_responses.dig(:date_of_birth, :year),
       autocomplete: "bday-year",
     }
   ]

--- a/app/views/coronavirus_form/dietary_requirements.html.erb
+++ b/app/views/coronavirus_form/dietary_requirements.html.erb
@@ -26,7 +26,7 @@
           id: ("dietary_requirements" if index == 0),
           value: item[:label],
           text: item[:label],
-          checked: session[:dietary_requirements] == item[:label],
+          checked: @form_responses[:dietary_requirements] == item[:label],
         }
       end
     } %>

--- a/app/views/coronavirus_form/essential_supplies.html.erb
+++ b/app/views/coronavirus_form/essential_supplies.html.erb
@@ -26,7 +26,7 @@
           id: ("essential_supplies" if index == 0),
           value: item[:label],
           text: item[:label],
-          checked: session[:essential_supplies] == item[:label],
+          checked: @form_responses[:essential_supplies] == item[:label],
         }
       end
     } %>

--- a/app/views/coronavirus_form/know_nhs_number.html.erb
+++ b/app/views/coronavirus_form/know_nhs_number.html.erb
@@ -29,7 +29,7 @@
           id: ("know_nhs_number" if index == 0),
           value: item[:label],
           text: item[:label],
-          checked: session[:know_nhs_number] == item[:label],
+          checked: @form_responses[:know_nhs_number] == item[:label],
         }
       end
     } %>

--- a/app/views/coronavirus_form/live_in_england.html.erb
+++ b/app/views/coronavirus_form/live_in_england.html.erb
@@ -22,7 +22,7 @@
       id: ("live_in_england" if index == 0),
       value: item[:label],
       text: item[:label],
-      checked: session[:live_in_england] == item[:label],
+      checked: @form_responses[:live_in_england] == item[:label],
     }
   end
 } %>

--- a/app/views/coronavirus_form/medical_conditions.html.erb
+++ b/app/views/coronavirus_form/medical_conditions.html.erb
@@ -2,7 +2,7 @@
     <% content_for :meta_tags do %>
       <meta name="description" content="<%= t('coronavirus_form.questions.medical_conditions.title') %>" />
     <% end %>
-    
+
     <% content_for :back_link do %>
       <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
     <% end %>
@@ -13,7 +13,7 @@
       <% end %>
     <% end %>
 
-    
+
     <%= form_tag({},
       "data-module": "track-coronavirus-form-vulnerable-people-medical_conditions",
       "data-question-key": "medical_conditions",
@@ -30,7 +30,7 @@
           id: ("medical_conditions" if index == 0),
           value: item[:label],
           text: item[:label],
-          checked: session[:medical_conditions] == item[:label],
+          checked: @form_responses[:medical_conditions] == item[:label],
         }
       end
     } %>

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -33,7 +33,7 @@
   id: "first_name",
   name: "first_name",
   error_message: error_items("first_name"),
-  value: session.dig(:name, "first_name"),
+  value: @form_responses.dig(:name, "first_name"),
   autocomplete: "given-name",
 } %>
 
@@ -44,7 +44,7 @@
   id: "middle_name",
   name: "middle_name",
   error_message: error_items("middle_name"),
-  value: session.dig(:name, "middle_name"),
+  value: @form_responses.dig(:name, "middle_name"),
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -54,7 +54,7 @@
   id: "last_name",
   name: "last_name",
   error_message: error_items("last_name"),
-  value: session.dig(:name, "last_name"),
+  value: @form_responses.dig(:name, "last_name"),
   autocomplete: "family-name",
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/app/views/coronavirus_form/nhs_letter.html.erb
+++ b/app/views/coronavirus_form/nhs_letter.html.erb
@@ -26,7 +26,7 @@
       id: ("nhs_letter" if index == 0),
       value: item[:label],
       text: item[:label],
-      checked: session[:nhs_letter] == item[:label],
+      checked: @form_responses[:nhs_letter] == item[:label],
     }
   end
 } %>

--- a/app/views/coronavirus_form/nhs_number.html.erb
+++ b/app/views/coronavirus_form/nhs_number.html.erb
@@ -26,7 +26,7 @@
       hint: sanitize(t("coronavirus_form.questions.nhs_number.hint")),
       type: "number",
       error_message: error_items('nhs_number'),
-      value: session[:nhs_number],
+      value: @form_responses[:nhs_number],
       width: 10,
     } %>
 

--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -33,7 +33,7 @@
   name: "building_and_street_line_1",
   type: "text",
   error_message: error_items('building_and_street_line_1'),
-  value: session.dig(:support_address, "building_and_street_line_1"),
+  value: @form_responses.dig(:support_address, :building_and_street_line_1),
   autocomplete: "address-line1",
 } %>
 
@@ -44,7 +44,7 @@
   id: "building_and_street_line_2",
   name: "building_and_street_line_2",
   error_message: error_items('building_and_street_line_2'),
-  value: session.dig(:support_address, "building_and_street_line_2"),
+  value: @form_responses.dig(:support_address, :building_and_street_line_2),
   autocomplete: "address-line2",
 } %>
 
@@ -56,7 +56,7 @@
   name: "town_city",
   type: "text",
   error_message: error_items('town_city'),
-  value: session.dig(:support_address, "town_city"),
+  value: @form_responses.dig(:support_address, :town_city),
   width: 20,
   autocomplete: "address-level2",
 } %>
@@ -69,7 +69,7 @@
   name: "county",
   type: "text",
   error_message: error_items('county'),
-  value: session.dig(:support_address, "county"),
+  value: @form_responses.dig(:support_address, :county),
   width: 20,
 } %>
 
@@ -81,7 +81,7 @@
   name: "postcode",
   type: "text",
   error_message: error_items('postcode'),
-  value: session.dig(:support_address, "postcode"),
+  value: @form_responses.dig(:support_address, :postcode),
   width: 10,
   autocomplete: "postal-code",
 } %>

--- a/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe CoronavirusForm::NhsNumberController, type: :controller do
 
   describe "POST submit" do
     it "sets session variables" do
-      post :submit, params: { nhs_number: "485 777 3456" }
-      expect(session[session_key]).to eq "4857773456"
+      post :submit, params: { nhs_number: valid_nhs_number }
+      expect(session[session_key]).to eq "1101230614"
     end
 
     it "validates the nhs_number is required" do

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
         "building_and_street_line_2" => '<a href="https://www.example.com">Link</a>',
         "town_city" => '<a href="https://www.example.com">Link</a>',
         "county" => '<a href="https://www.example.com">Link</a>',
+        "postcode" => '<a href="https://www.example.com">E1 8QS</a>',
       }
 
       address = {
@@ -58,7 +59,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
         building_and_street_line_2: "Link",
         town_city: "Link",
         county: "Link",
-        postcode: nil,
+        postcode: "E1 8QS",
       }
 
       post :submit, params: params


### PR DESCRIPTION
We are currently saving invalid responses to the session store before doing validations.  This means a user can submit an invalid response by browsing back to the "check your answers" page. 

To resolve this, we need to validate the response before updating the session store, but still replay the invalid response back to the user so they can correct it.  This changes the ordering of logic in the question controllers so we only update the session store values if validation has been successful.

Additionally, this PR:
- removes all use of session out of the views
- fixes two tests which were not correctly set up (but masked by the session hash being updated before validation took place)
- (as an unintentional side effect) resolves all string vs symbols issues for the stored session values, using symbols throughout now

Trello card: https://trello.com/c/PygFKz9a