### PR TITLE
Fix issues from #230

### DIFF
--- a/app/controllers/coronavirus_form/live_in_england_controller.rb
+++ b/app/controllers/coronavirus_form/live_in_england_controller.rb
@@ -5,8 +5,8 @@ class CoronavirusForm::LiveInEnglandController < ApplicationController
 
   def submit
     @form_responses = {
-    live_in_england: strip_tags(params[:live_in_england]).presence,
-  }
+      live_in_england: strip_tags(params[:live_in_england]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -3,8 +3,8 @@
 class CoronavirusForm::MedicalConditionsController < ApplicationController
   def submit
     @form_responses = {
-    medical_conditions: strip_tags(params[:medical_conditions]).presence,
-  }
+      medical_conditions: strip_tags(params[:medical_conditions]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
 module FieldValidationHelper
-  def validate_mandatory_text_fields(mandatory_fields, page, form_responses)
-    invalid_fields = []
-    mandatory_fields.each do |field|
-      next if form_responses[field].present?
-
-      invalid_fields << { field: field.to_s,
-                          text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",
-                                  default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.#{page}.#{field}.label")).humanize) }
-    end
-    invalid_fields
-  end
-
   def validate_radio_field(page, radio:, other: false)
     if radio.blank?
       return [{ field: page.to_s,


### PR DESCRIPTION
- Fixed indentation problem that rubocop did not pick up
- Removes unused `validate_mandatory_text_fields` method from field validation helper