### PR TITLE
Remove Postgres database service from PaaS manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,6 @@ applications:
   buildpack: ruby_buildpack
   memory: 2G
   services:
-  - govuk-coronavirus-vulnerable-people-form-db
   - logit-ssl-drain
   - splunk-ssl-drain
   env:


### PR DESCRIPTION
- We use Dynamo in this app and we don't need to keep this Postgres db
  hanging around in Staging or Production.