### PR TITLE
Use Github Actions for PR builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      dynamodb:
+        image: amazon/dynamodb-local
+        ports: ["8000:8000"]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.5
+
+    - name: Build App
+      env:
+        RAILS_ENV: test
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+    - name: Run Tests
+      env:
+        RAILS_ENV: test
+      run: |
+        bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+  - master
 language: ruby
 cache: bundler
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Run tests](https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/workflows/Run%20tests/badge.svg)
+
 # CoronavirusForm
 
 This is an application for submitting a form.


### PR DESCRIPTION
Trello: https://trello.com/c/r22AVt8W/207-switch-the-pr-builds-on-all-forms-to-use-github-actions-not-travis
Trello: https://trello.com/c/TNaiKhFV/228-make-travis-only-build-against-master