### PR TITLE
Revert changes to skip medical conditions question

### DIFF
--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -41,6 +41,6 @@ private
   end
 
   def previous_path
-    session[:medical_conditions].blank? ? nhs_letter_path : medical_conditions_path
+    medical_conditions_path
   end
 end

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -19,22 +19,15 @@ class CoronavirusForm::NhsLetterController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
-      update_session_store
+      session[:nhs_letter] = @form_responses[:nhs_letter]
       redirect_to check_your_answers_url
-    elsif @form_responses[:nhs_letter] == I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
-      update_session_store
-      redirect_to name_url
     else
-      update_session_store
+      session[:nhs_letter] = @form_responses[:nhs_letter]
       redirect_to medical_conditions_url
     end
   end
 
 private
-
-  def update_session_store
-    session[:nhs_letter] = @form_responses[:nhs_letter]
-  end
 
   def previous_path
     live_in_england_path

--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -18,8 +18,7 @@ module AnswersHelper
   end
 
   def skip_question?(question, answer)
-    questions_to_skip = %w(nhs_number medical_conditions)
-    questions_to_skip.include?(question) && answer.nil?
+    question == "nhs_number" && answer.nil?
   end
 
   def concat_answer(answer, question)

--- a/features/form.feature
+++ b/features/form.feature
@@ -9,7 +9,7 @@ Feature: Filling in the form
     Then I can see "Do you live in England?" in the heading
     When I answer "Yes"
     Then I can see "Have you recently had a letter from the NHS" in the heading
-    When I answer "No"
+    When I answer "Yes"
     Then I can see "Do you have one of the listed medical conditions" in the heading
     When I answer "Yes, I have one of the listed medical conditions"
     Then I can see "What is your name?" in the heading
@@ -55,13 +55,7 @@ Feature: Filling in the form
   Scenario: No eligible medical condition
     When I visit the "/live-in-england" path
     And I answer "Yes"
-    And I answer "No"
+    And I answer "Yes"
     And I answer "No, I do not have one of the listed medical conditions - and I have not been told to ‘shield’"
     Then I will be redirected to the "/not-eligible-medical" path
     And I can see "Sorry, you’re not eligible for help through this service" in the heading
-
-    Scenario: Received NHS letter skips medical conditions question
-      When I visit the "/live-in-england" path
-      And I answer "Yes"
-      And I answer "Yes"
-      Then I will be redirected to the "/name" path

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -41,18 +41,8 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
       expect(response).to render_template(current_template)
     end
 
-    it "redirects to name question for a yes response" do
-      post :submit, params: { nhs_letter: I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label") }
-      expect(response).to redirect_to(name_path)
-    end
-
-    it "redirects to medical conditions question for a no response" do
-      post :submit, params: { nhs_letter: I18n.t("coronavirus_form.questions.nhs_letter.options.option_no.label") }
-      expect(response).to redirect_to(medical_conditions_path)
-    end
-
-    it "redirects to medical conditions question for a not sure response" do
-      post :submit, params: { nhs_letter: I18n.t("coronavirus_form.questions.nhs_letter.options.option_not_sure.label") }
+    it "redirects to next step for a permitted response" do
+      post :submit, params: { nhs_letter: selected }
       expect(response).to redirect_to(medical_conditions_path)
     end
 

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -22,21 +22,6 @@ RSpec.describe AnswersHelper, type: :helper do
         )
       end
     end
-
-    context "medical_conditions" do
-      it "includes the medical conditions question if it has a value" do
-        session[:medical_conditions] = "Yes"
-        expect(helper.answer_items.pluck(:field)).to include(
-          I18n.t("coronavirus_form.questions.medical_conditions.title"),
-        )
-      end
-
-      it "skips the medical conditions question if the value is nil" do
-        expect(helper.answer_items.pluck(:field)).to_not include(
-          I18n.t("coronavirus_form.questions.medical_conditions.title"),
-        )
-      end
-    end
   end
 
   describe "#concat_answer" do


### PR DESCRIPTION
In https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/245, we introduced a change where users would skip the medical conditions question if they have received the NHS letter.

Unfortunately, this causes downstream changes to the data (no value included for `medical_conditions`) which has the potential to break the data processing.

Therefore reverting the change so users will always see the medical conditions question.

Trello card: https://trello.com/c/Su3H5Rn7