### PR TITLE
ci/travis: Only run on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+  - master
 language: ruby
 cache: bundler
 before_script:


### PR DESCRIPTION
- Now we've got GitHub Actions running for PR builds, we don't need to
  run Travis PR builds at the same time, so we can save a bit of the
  planet by only running the Travis checks on `master` (which we still
  need to do because the Concourse release process triggers on a
  successful Travis `master` build).