### PR TITLE
Remove all whitespace from postcode

### DIFF
--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -14,7 +14,7 @@ class CoronavirusForm::SupportAddressController < ApplicationController
         building_and_street_line_2: strip_tags(params[:building_and_street_line_2]&.strip).presence,
         town_city: strip_tags(params[:town_city]&.strip).presence,
         county: strip_tags(params[:county]&.strip).presence,
-        postcode: strip_tags(params[:postcode]&.strip).presence,
+        postcode: strip_tags(params[:postcode]&.gsub(/[[:space:]]+/, "")).presence,
       },
     }
 

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
         building_and_street_line_2: "1 Horse Guards Road",
         town_city: "London",
         county: "United Kingdom",
-        postcode: "SW1A 2HQ",
+        postcode: "SW1A2HQ",
       }
     end
 
@@ -51,7 +51,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
         "building_and_street_line_2" => '<a href="https://www.example.com">Link</a>',
         "town_city" => '<a href="https://www.example.com">Link</a>',
         "county" => '<a href="https://www.example.com">Link</a>',
-        "postcode" => '<a href="https://www.example.com">E1 8QS</a>',
+        "postcode" => '<a href="https://www.example.com">E18QS</a>',
       }
 
       address = {
@@ -59,7 +59,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
         building_and_street_line_2: "Link",
         town_city: "Link",
         county: "Link",
-        postcode: "E1 8QS",
+        postcode: "E18QS",
       }
 
       post :submit, params: params
@@ -117,12 +117,12 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       expect(response).to render_template(current_template)
     end
 
-    it "removes extra whitespace from the postcode" do
+    it "removes all whitespace from the postcode" do
       params[:postcode] = "E1 8QS "
       post :submit, params: params
 
       expect(response).to redirect_to(next_page)
-      expect(session[session_key][:postcode]).to eq("E1 8QS")
+      expect(session[session_key][:postcode]).to eq("E18QS")
     end
 
     described_class::REQUIRED_FIELDS.each do |field|


### PR DESCRIPTION
Trello: https://trello.com/c/hUsoCjYe

## Motivation
Users sometimes enter their postcode with extra spaces, e.g "e1 8 qs"
which fails validation. This caused quite a few users to contact
support.

We need to update the validator so we accept valid postcodes that are
entered in the incorrect format, so users are not being rejected when
they enter a valid postcode.