### PR TITLE
Add opt-in Google Analytics tracking

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -1,0 +1,25 @@
+// Start cookie banner (display settings controlled internally by cookies)
+var element = document.querySelector('[data-module="cookie-banner"]')
+new GOVUK.Modules.CookieBanner().start($(element))
+
+var analyticsInit = function() {
+  <% if Rails.application.config.analytics_tracking_id.present? %>
+    var trackingId = "<%= Rails.application.config.analytics_tracking_id %>"
+
+    // Start analytics only if we have user consent
+    var consentCookie = window.GOVUK.getConsentCookie();
+    if (consentCookie && consentCookie["usage"]) {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga')
+
+      ga('create', trackingId, 'auto')
+      ga('set', 'allowAdFeatures', false);
+      ga('set', 'anonymizeIp', true);
+      ga('send', 'pageview');
+    }
+  <% end %>
+}
+
+window.GOVUK.analyticsInit = analyticsInit

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,9 @@
+//= require jquery
 // = require govuk/all.js
+//= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/lib/cookie-functions
+//= require analytics
+//= require cookies
 window.GOVUKFrontend.initAll()
+window.CookieSettings.start()
+window.GOVUK.analyticsInit()

--- a/app/assets/javascripts/cookies.js
+++ b/app/assets/javascripts/cookies.js
@@ -1,0 +1,77 @@
+window.GOVUK = window.GOVUK || {}
+
+function CookieSettings () {}
+
+CookieSettings.start = function () {
+
+  var cookieForm = document.querySelector('form[data-module=cookie-settings]');
+
+  if (cookieForm) {
+    cookieForm.addEventListener('submit', this.submitSettingsForm)
+    this.setInitialFormValues()
+  }
+}
+
+CookieSettings.setInitialFormValues = function () {
+  if (!window.GOVUK.cookie('cookies_policy')) {
+    window.GOVUK.setDefaultConsentCookie()
+  }
+
+  var currentConsentCookie = window.GOVUK.cookie('cookies_policy')
+  var currentConsentCookieJSON = JSON.parse(currentConsentCookie)
+
+  // We don't need the essential value as this cannot be changed by the user
+  delete currentConsentCookieJSON["essential"]
+  // We don't need the campaigns/settings values as these aren't required by
+  // the service.
+  delete currentConsentCookieJSON["campaigns"]
+  delete currentConsentCookieJSON["settings"]
+
+  for (var cookieType in currentConsentCookieJSON) {
+    var radioButton
+
+    if (currentConsentCookieJSON[cookieType]) {
+      radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=on]')
+    } else {
+      radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=off]')
+    }
+
+    radioButton.checked = true
+  }
+}
+
+CookieSettings.submitSettingsForm = function (event) {
+  event.preventDefault()
+
+  var formInputs = event.target.getElementsByTagName("input")
+  var options = {}
+
+  for ( var i = 0; i < formInputs.length; i++ ) {
+    var input = formInputs[i]
+    if (input.checked) {
+      var name = input.name.replace('cookies-', '')
+      var value = input.value === "on" ? true : false
+
+      options[name] = value
+    }
+  }
+
+  window.GOVUK.setConsentCookie(options)
+  window.GOVUK.setCookie('cookies_preferences_set', true, { days: 365 });
+
+  CookieSettings.showConfirmationMessage()
+
+  if (window.GOVUK.analyticsInit) {
+    window.GOVUK.analyticsInit()
+  }
+
+  return false
+}
+
+CookieSettings.showConfirmationMessage = function () {
+  var confirmationMessage = document.querySelector('div[data-cookie-confirmation]')
+
+  document.body.scrollTop = document.documentElement.scrollTop = 0
+
+  confirmationMessage.style.display = "block"
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 @import 'govuk_publishing_components/components/_phase-banner';
 @import 'govuk_publishing_components/components/_back-link';
 @import 'govuk_publishing_components/components/_breadcrumbs';
+@import 'govuk_publishing_components/components/cookie-banner';
 
 @import 'govuk_publishing_components/components/_title';
 @import 'govuk_publishing_components/components/_heading';
@@ -19,6 +20,7 @@
 @import 'govuk_publishing_components/components/_layout-footer';
 
 @import 'govuk_publishing_components/components/_summary-list';
+@import 'govuk_publishing_components/components/table';
 @import 'govuk_publishing_components/components/_panel';
 
 @import 'govuk_publishing_components/components/_fieldset';
@@ -28,6 +30,8 @@
 @import 'govuk_publishing_components/components/_label';
 @import 'govuk_publishing_components/components/_radio';
 @import 'govuk_publishing_components/components/_button';
+
+@import 'cookie-settings';
 
 .app-list--spaced > li {
     margin-bottom: govuk-spacing(3);

--- a/app/assets/stylesheets/cookie-settings.scss
+++ b/app/assets/stylesheets/cookie-settings.scss
@@ -1,0 +1,29 @@
+.cookie-settings__form-wrapper {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+  }
+}
+
+.cookie-settings__no-js {
+  .js-enabled & {
+    display: none;
+  }
+}
+
+.cookie-settings__list {
+  list-style-type: initial;
+  margin: govuk-spacing(4);
+  padding-left: govuk-spacing(6);
+}
+
+.cookie-settings__confirmation {
+  @include govuk-font(19);
+  display: none;
+  margin-top: govuk-spacing(3);
+}
+
+.cookies-content {
+  @include govuk-font(19);
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,12 @@
 class ApplicationController < ActionController::Base
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :session_expired
 
   before_action :check_first_question, only: [:show]
+  before_action :set_session_history, only: :show
 
   def show
     @form_responses = session.to_hash.with_indifferent_access
@@ -26,6 +28,13 @@ private
 
   helper_method :previous_path
 
+  def set_session_history
+    if session[:current_path] != request.path
+      session[:previous_path] = session[:current_path]
+    end
+    session[:current_path] = request.path
+  end
+
   def previous_path
     raise NotImplementedError, "Define a previous path"
   end
@@ -41,11 +50,5 @@ private
   def session_expired
     reset_session
     redirect_to session_expired_path
-  end
-
-  def check_first_question
-    if session[:live_in_england].blank?
-      redirect_to controller: "coronavirus_form/live_in_england", action: "show"
-    end
   end
 end

--- a/app/controllers/coronavirus_form/cookies_controller.rb
+++ b/app/controllers/coronavirus_form/cookies_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::CookiesController < ApplicationController
+  skip_before_action :check_first_question
+
+  def show
+    @previous_page = return_path
+    super
+  end
+
+private
+
+  def return_path
+    return first_question_path if session[:previous_path].blank?
+
+    path = URI(session[:previous_path]).path
+    path.presence || first_question_path
+  end
+end

--- a/app/helpers/form_flow_helper.rb
+++ b/app/helpers/form_flow_helper.rb
@@ -1,0 +1,21 @@
+module FormFlowHelper
+  FIRST_QUESTION = "live_in_england".freeze
+
+  def check_first_question
+    redirect_to_first_question unless first_question_answered?
+  end
+
+  def redirect_to_first_question
+    redirect_to controller: "coronavirus_form/#{FIRST_QUESTION}", action: "show"
+  end
+
+  def first_question_path
+    FIRST_QUESTION.dasherize
+  end
+
+private
+
+  def first_question_answered?
+    session[FIRST_QUESTION.to_sym].present?
+  end
+end

--- a/app/views/coronavirus_form/cookies.html.erb
+++ b/app/views/coronavirus_form/cookies.html.erb
@@ -1,0 +1,77 @@
+<% content_for :title, t("cookies.title") %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t("cookies.title") %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: @previous_page } %>
+<% end %>
+
+<main class="cookies-content">
+  <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
+    <%= render "govuk_publishing_components/components/notice", {
+      title: t("cookies.title"),
+      aria_live: true,
+    } do %>
+      <p><%= "Your cookie settings were saved" %></p>
+      <a class="govuk-link cookie-settings__prev-page" href="<%= @previous_page %>">
+        <%= "Go back to the page you were looking at" %>
+      </a>
+    <% end %>
+  </div>
+
+  <%= render "govuk_publishing_components/components/title", {
+    title: t("cookies.title"),
+    margin_top: 0,
+  } %>
+
+  <%= tag.p t('cookies.settings_page.intro_html'), class: "govuk-body" %>
+
+  <div class="cookie-settings__no-js">
+    <%= render "govuk_publishing_components/components/govspeak", {
+      } do %>
+      <p>We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
+      <ul>
+        <li>reloading the page</li>
+        <li>turning on Javascript in your browser</li>
+      </ul>
+    <% end %>
+  </div>
+
+  <div class="cookie-settings__form-wrapper">
+    <p>
+      We use <%= t('cookies.settings_page.cookies').count %> types of cookie.
+      You can choose which cookies you're happy for us to use.
+    </p>
+
+    <form data-module="cookie-settings">
+      <% t('cookies.settings_page.cookies').map do |cookie_item| %>
+        <% cookies_usage_hint = capture do %>
+          <div class="govuk-body">
+            <p><%= sanitize(cookie_item.dig(:text_html)) %></p>
+            <%= render "govuk_publishing_components/components/table", {
+              head: [
+                { text: "Name" },
+                { text: "Purpose" },
+                { text: "Expires" },
+              ],
+              rows: cookie_item.dig(:cookies),
+            } %>
+          </div>
+        <% end %>
+
+        <%= render "govuk_publishing_components/components/radio", {
+          name: cookie_item.dig(:cookie_options_name),
+          inline: false,
+          heading: cookie_item.dig(:header),
+          hint: (cookies_usage_hint),
+          items: cookie_item.fetch(:cookie_options, []),
+        } %>
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save changes"
+      } %>
+    </form>
+  </div>
+</main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,30 @@
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
+    <%= render "govuk_publishing_components/components/cookie_banner", {
+      title: t("cookies.banner.title"),
+      text: t("cookies.banner.text"),
+      confirmation_message: sanitize(t("cookies.banner.confirmation_message")),
+      cookie_preferences_href: cookies_path,
+      services_cookies: {
+        yes: {
+          text: "Yes",
+          data_attributes: {
+            "track-category": "cookieBanner"
+          }
+        },
+        no: {
+          text: "No",
+          data_attributes: {
+            "track-category": "cookieBanner"
+          }
+        },
+        cookie_preferences: {
+          text: "How we use cookies",
+          href: cookies_path
+        }
+      }
+    } %>
     <%= render "govuk_publishing_components/components/skip_link" %>
     <%= render "govuk_publishing_components/components/layout_header", { environment: "public" } %>
     <div class="govuk-width-container">
@@ -39,6 +63,10 @@
           {
             href: "/privacy",
             text: t("privacy_page.title")
+          },
+          {
+            href: "/cookies",
+            text: t("cookies.title")
           },
           {
             href: "/accessibility-statement",

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -12,6 +12,7 @@ params:
   CF_USERNAME: ((paas-username))
   CF_PASSWORD: ((paas-password))
   CF_ORG: govuk_development
+  GA_VIEW_ID: UA-43115970-1
   SENTRY_DSN: https://((sentry-dsn))
   SECRET_KEY_BASE:
   CF_STARTUP_TIMEOUT:
@@ -49,6 +50,7 @@ run:
       cf set-env govuk-coronavirus-vulnerable-people-form AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID"
       cf set-env govuk-coronavirus-vulnerable-people-form AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
       cf set-env govuk-coronavirus-vulnerable-people-form SECRET_KEY_BASE "$SECRET_KEY_BASE"
+      cf set-env govuk-coronavirus-business-volunteer-form GA_VIEW_ID "$GA_VIEW_ID"
 
       cf v3-zdt-push govuk-coronavirus-vulnerable-people-form --wait-for-deploy-complete --no-route
       cf map-route govuk-coronavirus-vulnerable-people-form cloudapps.digital --hostname "$HOSTNAME"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,8 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
+  config.analytics_tracking_id = "12345"
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,6 +86,8 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
+  config.analytics_tracking_id = ENV["GA_VIEW_ID"]
+
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,6 +36,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.analytics_tracking_id = "12345"
+
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,2 @@
+# If you change this, you should also change the Cookies page text.
 Rails.application.config.session_store :cookie_store, expire_after: 4.hours

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,62 @@ en:
       <h2 class="govuk-heading-m">How we tested this website</h2>
       <p class="govuk-body">This website was last tested on 27 March 2020. The test was carried out by the Government Digital Service, based on the <a class="govuk-link" href="https://design-system.service.gov.uk/accessibility/">accessibility statement for the GOV.UK Design System</a>.</p>
       <p class="govuk-body">This statement was prepared on 27 March 2020. It was last updated on 27 March 2020.</p>
+  cookies:
+    title: Cookies
+    banner:
+      title: "Can we store analytics cookies on your device?"
+      text: "Analytics cookies help us understand how our website is being used."
+      confirmation_message: "You’ve accepted all cookies. You can <a class='govuk-link' href='/cookies'>change your cookie settings</a> at any time."
+    settings_page:
+      intro_html: |
+        This service puts small files (known as 'cookies') onto your computer.
+        <br><br>
+        Cookies are used to:
+        <ul class="govuk-list govuk-list--bullet">
+          <li>keep which question you’re up to and how you’ve answered previous questions</li>
+          <li>measure how you use the website so it can be updated and improved based on your needs.</li>
+        </ul>
+        <a class="govuk-link" href="https://ico.org.uk/your-data-matters/online/cookies/">Find out how to manage cookies</a>
+      cookies:
+        - header: Essential cookies
+          text_html: These cookies are required for this service to operate. We do not need to ask permission to use them.
+          cookies:
+            - - text: cookie_preferences_set
+              - text: Lets us know whether you've already set your cookies preferences.
+              - text: 1 year
+            - - text: cookie_preferences
+              - text: Let us know what your cookie preferences are.
+              - text: 1 year
+            - - text: _sessions_store
+              - text: Remembers which question you’re up to and how you answered previous questions.
+              - text: 4 hours
+        - header: Measuring website usage with Google Analytics (analytics cookies)
+          text_html: |
+            We use Google Analytics software to collect anonymised information about how you use the service. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
+            Google Analytics stores information about:
+            <ul class="cookie-settings__list">
+              <li>the pages you visit</li>
+              <li>how long you spend on each page</li>
+              <li>how you arrived at the site</li>
+              <li>what you click on while you’re visiting the site</li>
+              <li>the device and browser you’re using</li>
+            </ul>
+            We don’t collect or store your personal information (for example your name or address) so this information can’t be used to identify who you are.
+            We don’t allow Google to use or share our analytics data.
+            Google Analytics sets the following cookies:
+          cookie_options_name: "cookies-usage"
+          cookie_options:
+            - value: "on"
+              text: Use cookies that measure my website use
+            - value: "off"
+              text: Do not use cookies that measure my website use
+          cookies:
+            - - text: _ga
+              - text: This helps us count how many people visit the service by tracking if you’ve visited before
+              - text: 2 years
+            - - text: _gid
+              - text: This helps us count how many people visit the service by tracking if you’ve visited before
+              - text: 3 years
   privacy_page:
     title: Privacy
     body_text: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   scope module: "coronavirus_form" do
     get "/privacy", to: "privacy#show"
     get "/accessibility-statement", to: "accessibility_statement#show"
+    get "/cookies", to: "cookies#show"
 
     get "/session-expired", to: "session_expired#show"
 


### PR DESCRIPTION
This adds Google Analytics to the form, to help us understand
how people are using the service to offer help, so the development
team can make improvements.

User tracking will only be enabled if the users opts in.

This uses the cookie banner component, and copies the approach
(cookie settings page) from GOV.UK for this service.

If a user opts in to usage tracking, we'll load Google Analytics
so we can see how users move through the form in aggregate, in
order to improve the application.

Every page will have a cookie banner until the user accepts or
rejects cookies.

## Screenshots

**Cookie page**

![localhost_5000_cookies](https://user-images.githubusercontent.com/8124374/79259038-f685c980-7e83-11ea-9ad1-2f0582ee45f2.png)

**Banner**

<img width="696" alt="Screenshot 2020-04-14 at 19 00 34" src="https://user-images.githubusercontent.com/8124374/79259081-06051280-7e84-11ea-8455-da8f4a05f317.png">

**Banner after accept**

<img width="690" alt="Screenshot 2020-04-14 at 19 02 39" src="https://user-images.githubusercontent.com/8124374/79259100-0e5d4d80-7e84-11ea-9bb4-c945c6f68cb7.png">

https://trello.com/c/ytRb9HIU/152