### PR TITLE
ci: Optimise Actions runs by caching `bundle install`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,21 @@ jobs:
       with:
         ruby-version: 2.6.5
 
+    - uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
     - name: Build App
       env:
         RAILS_ENV: test
       run: |
         gem install bundler
+        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
+
     - name: Run Tests
       env:
         RAILS_ENV: test


### PR DESCRIPTION
The "build app" portion of our builds take four minutes every time.
This is a lot slower than Travis. So we can cache bundle install and
see if that improves things.