### PR TITLE
Don't put smoke test data into database

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -19,11 +19,13 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
     session[:reference_id] = submission_reference
 
-    FormResponse.create(
-      ReferenceId: submission_reference,
-      UnixTimestamp: Time.zone.now,
-      FormResponse: session,
-    )
+    unless smoke_tester?
+      FormResponse.create(
+        ReferenceId: submission_reference,
+        UnixTimestamp: Time.zone.now,
+        FormResponse: session,
+      )
+    end
 
     reset_session
 
@@ -31,6 +33,11 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
   end
 
 private
+
+  def smoke_tester?
+    email = session.dig(:contact_details, :email)
+    email.present? && email == Rails.application.config.courtesy_copy_email
+  end
 
   def reference_number
     timestamp = Time.zone.now.strftime("%Y%m%d-%H%M%S")

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,8 @@ module CoronavirusForm
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.courtesy_copy_email = "coronavirus-services-smoke-tests@digital.cabinet-office.gov.uk"
+
     # Don't generate system test files.
     config.generators.system_tests = nil
   end

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -65,5 +65,14 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
 
       expect(FormResponse.last.attributes.dig(:FormResponse, :medical_conditions)).to eq("Yes, I have one of the medical conditions on the list")
     end
+
+    it "doesn't create a FormResponse if the user is the smoke tester" do
+      session[:contact_details] = { email: Rails.application.config.courtesy_copy_email }
+      session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_gp.label")
+
+      expect {
+        post :submit
+      }.to_not(change { FormResponse.count })
+    end
   end
 end

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       {
         "phone_number_calls" => "1234<script></script>",
         "phone_number_texts" => "5678",
-        "email" => "<script></script>somewhere@somewhere.com",
+        "email" => "<script></script>tester@example.org",
       }
     end
 
@@ -31,7 +31,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       {
         phone_number_calls: "1234",
         phone_number_texts: "5678",
-        email: "somewhere@somewhere.com",
+        email: "tester@example.org",
       }
     end
 

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe AnswersHelper, type: :helper do
         answer = {
           "phone_number_calls" => "012101234567",
           "phone_number_texts" => "0777001234567",
-          "email" => "me@example.com",
+          "email" => "tester@example.org",
         }
 
         expected_answer =
@@ -55,7 +55,7 @@ RSpec.describe AnswersHelper, type: :helper do
 
       it "only concatenates the fields that have a value" do
         answer = {
-          "email" => "me@example.com",
+          "email" => "tester@example.org",
         }
 
         expected_answer = "Email: #{answer['email']}"

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -82,7 +82,7 @@ module FillInTheFormSteps
     within find(".govuk-main-wrapper") do
       fill_in "phone_number_calls", with: "07000000000"
       fill_in "phone_number_texts", with: "07000000000"
-      fill_in "email", with: "test@example.com"
+      fill_in "email", with: Rails.application.config.courtesy_copy_email
       click_on I18n.t("coronavirus_form.submit_and_next")
     end
   end


### PR DESCRIPTION
This will ensure we don't create a FormResponse record when the smoke tester completes the form.

https://trello.com/c/yEHNJoNp/256-stop-smoke-tests-putting-test-data-into-the-production-database