### PR TITLE
Rename db in development and test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,12 +6,12 @@ default: &default
 
 development:
   <<: *default
-  database: coronavirus_form_development
+  database: coronavirus_vulnerable_people_form_development
   url: <%= ENV["DATABASE_URL"]%>
 
 test:
   <<: *default
-  database: coronavirus_form_test
+  database: coronavirus_vulnerable_people_form_test
   url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:


### PR DESCRIPTION
The vulnerable people, business volunteer and find support forms all use the same
database names in development and testing. This is fine in production where they're
all hosted on different RDS instances, but can produce some interesting results locally.

Need to run bundle exec rails dynamoid:create_tables to setup the db again.