### PR TITLE
Allow Heroku to be used for review apps

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,4 +51,8 @@ private
     reset_session
     redirect_to session_expired_path
   end
+
+  def preview_app?
+    ENV["HEROKU_APP_NAME"]
+  end
 end

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -19,7 +19,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
     session[:reference_id] = submission_reference
 
-    unless smoke_tester?
+    unless smoke_tester? || preview_app?
       FormResponse.create(
         ReferenceId: submission_reference,
         UnixTimestamp: Time.zone.now,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,6 +11,8 @@ Rails.application.configure do
     "govuk-coronavirus-vulnerable-people-form-stg.cloudapps.digital",
   ]
 
+  config.hosts << "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" if ENV["HEROKU_APP_NAME"]
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/initializers/asset_sync.rb
+++ b/config/initializers/asset_sync.rb
@@ -1,5 +1,6 @@
 if defined?(AssetSync)
   AssetSync.configure do |config|
+    config.enabled = false if ENV["HEROKU_APP_NAME"]
     config.fog_provider = "AWS"
     config.fog_region = "eu-west-2"
     config.fog_directory = ENV["AWS_ASSETS_BUCKET_NAME"]

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
       )
     end
 
+    context "when running as a Heroku preview app" do
+      before do
+        ENV["HEROKU_APP_NAME"] = "coronavirus-form-preview"
+      end
+
+      it "does not save the form response to the database" do
+        expect { post :submit }.to_not(change { FormResponse.count })
+      end
+    end
+
     it "resets session" do
       post :submit
       expect(session.to_hash).to eq({})


### PR DESCRIPTION
This allows us to use Heroku for review apps.

It makes the following changes:
- Disables `AssetSync` when operating in Heroku - this stops assets from uploaded to AWS during precompilation, a step that was previously failing because AWS credentials were not specified.
- Allows the application URL `{}.herokuapp.com` to be a permitted host in `config.hosts` when running in Heroku only.
- Prevents writing to the database when operating as a preview app - this will allow us to conduct user research without concerns around personal data being collected.  The user can still submit the form and will see the confirmation page as usual.

In addition to this, I have created a [Heroku Pipeline](https://dashboard.heroku.com/pipelines/60263277-c437-4b6a-b824-c61d561de278) which is connected to this repo, so review apps are automatically created for each PR.

The `HEROKU_APP_NAME` environment variable is automatically injected into the review app by Heroku (see [docs](https://devcenter.heroku.com/articles/github-integration-review-apps#injected-environment-variables)).

Trello card: https://trello.com/c/WiCelarD