### PR TITLE
Use I18n lookup rather than hard-coded strings in tests

### DIFF
--- a/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
       get :show
       expect(response).to render_template(current_template)
     end

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/know_nhs_number_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CoronavirusForm::KnowNhsNumberController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/live_in_england_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/live_in_england_controller_spec.rb
@@ -39,25 +39,25 @@ RSpec.describe CoronavirusForm::LiveInEnglandController, type: :controller do
     end
 
     it "redirects to next step for a yes response" do
-      post :submit, params: { live_in_england: "Yes" }
+      post :submit, params: { live_in_england: I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label") }
       expect(response).to redirect_to(nhs_letter_path)
     end
 
     it "redirects to ineligible page for a no response" do
-      post :submit, params: { live_in_england: "No" }
+      post :submit, params: { live_in_england: I18n.t("coronavirus_form.questions.live_in_england.options.option_no.label") }
       expect(response).to redirect_to(not_eligible_england_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { live_in_england: "Yes" }
+      post :submit, params: { live_in_england: I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label") }
 
       expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "redirects to ineligible page for a no response when check your answers previously seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { live_in_england: "No" }
+      post :submit, params: { live_in_england: I18n.t("coronavirus_form.questions.live_in_england.options.option_no.label") }
 
       expect(response).to redirect_to(not_eligible_england_path)
     end

--- a/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/name_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/name_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CoronavirusForm::NameController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { nhs_letter: "Yes" }
+      post :submit, params: { nhs_letter: I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label") }
 
       expect(response).to redirect_to(check_your_answers_path)
     end

--- a/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CoronavirusForm::NhsNumberController, type: :controller do
   let(:valid_nhs_number) { "110 123 0614" }
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/not_eligible_england_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/not_eligible_england_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CoronavirusForm::NotEligibleEnglandController, type: :controller 
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/not_eligible_medical_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/not_eligible_medical_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CoronavirusForm::NotEligibleMedicalController, type: :controller 
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
 
   describe "GET show" do
     it "renders the form" do
-      session[:live_in_england] = "Yes"
+      session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
 
       get :show
       expect(response).to render_template(current_template)

--- a/spec/helpers/field_validation_helper_spec.rb
+++ b/spec/helpers/field_validation_helper_spec.rb
@@ -4,70 +4,70 @@ RSpec.describe FieldValidationHelper, type: :helper do
   context "#validate_date_of_birth" do
     it "returns an error if year is blank" do
       invalid_fields = validate_date_of_birth("", "6", "25", "date")
-      expect(invalid_fields).to eq [{ field: "date-year", text: "Enter your date of birth and include a day, month and year" }]
+      expect(invalid_fields).to eq [{ field: "date-year", text: I18n.t("coronavirus_form.errors.missing_fields") }]
     end
 
     it "returns an error if month is blank" do
       invalid_fields = validate_date_of_birth("1990", "", "25", "date")
-      expect(invalid_fields).to eq [{ field: "date-month", text: "Enter your date of birth and include a day, month and year" }]
+      expect(invalid_fields).to eq [{ field: "date-month", text: I18n.t("coronavirus_form.errors.missing_fields") }]
     end
 
     it "returns an error if day is blank" do
       invalid_fields = validate_date_of_birth("1990", "6", "", "date")
-      expect(invalid_fields).to eq [{ field: "date-day", text: "Enter your date of birth and include a day, month and year" }]
+      expect(invalid_fields).to eq [{ field: "date-day", text: I18n.t("coronavirus_form.errors.missing_fields") }]
     end
 
     it "returns an error if year is negative" do
       invalid_fields = validate_date_of_birth("-1990", "6", "25", "date")
-      expect(invalid_fields).to eq [{ field: "date-year", text: "Enter a real year" }]
+      expect(invalid_fields).to eq [{ field: "date-year", text: I18n.t("coronavirus_form.errors.negative_date", field: "year") }]
     end
 
     it "returns an error if month is negative" do
       invalid_fields = validate_date_of_birth("1990", "-6", "25", "date")
-      expect(invalid_fields).to eq [{ field: "date-month", text: "Enter a real month" }]
+      expect(invalid_fields).to eq [{ field: "date-month", text: I18n.t("coronavirus_form.errors.negative_date", field: "month") }]
     end
 
     it "returns an error if day is negative" do
       invalid_fields = validate_date_of_birth("1990", "6", "-25", "date")
-      expect(invalid_fields).to eq [{ field: "date-day", text: "Enter a real day" }]
+      expect(invalid_fields).to eq [{ field: "date-day", text: I18n.t("coronavirus_form.errors.negative_date", field: "day") }]
     end
 
     it "returns an error if year is not a number" do
       invalid_fields = validate_date_of_birth("Foo", "6", "25", "date")
-      expect(invalid_fields).to eq [{ field: "date-year", text: "Enter year as a number" }]
+      expect(invalid_fields).to eq [{ field: "date-year", text: I18n.t("coronavirus_form.errors.date_not_a_number", field: "year") }]
     end
 
     it "returns an error if month is not a number" do
       invalid_fields = validate_date_of_birth("1990", "Foo", "25", "date")
-      expect(invalid_fields).to eq [{ field: "date-month", text: "Enter month as a number" }]
+      expect(invalid_fields).to eq [{ field: "date-month", text: I18n.t("coronavirus_form.errors.date_not_a_number", field: "month") }]
     end
 
     it "returns an error if day is not a number" do
       invalid_fields = validate_date_of_birth("1990", "6", "Foo", "date")
-      expect(invalid_fields).to eq [{ field: "date-day", text: "Enter day as a number" }]
+      expect(invalid_fields).to eq [{ field: "date-day", text: I18n.t("coronavirus_form.errors.date_not_a_number", field: "day") }]
     end
 
     it "returns an error if no date is entered" do
       invalid_fields = validate_date_of_birth("", "", "", "date")
-      expect(invalid_fields).to eq [{ field: "date-day", text: "Enter your date of birth" }]
+      expect(invalid_fields).to eq [{ field: "date-day", text: I18n.t("coronavirus_form.errors.missing_date") }]
     end
 
     it "returns multiple errors if multiple date fields are blank" do
       invalid_fields = validate_date_of_birth("", "", "25", "date")
       expect(invalid_fields).to eq [
-        { field: "date-month", text: "Enter your date of birth and include a day, month and year" },
+        { field: "date-month", text: I18n.t("coronavirus_form.errors.missing_fields") },
       ]
     end
 
     it "returns an error if date is not valid" do
       invalid_fields = validate_date_of_birth("2019", "02", "30", "date")
-      expect(invalid_fields).to eq [{ field: "date-day", text: "Enter a real date of birth" }]
+      expect(invalid_fields).to eq [{ field: "date-day", text: I18n.t("coronavirus_form.errors.invalid_date") }]
     end
 
     it "returns an error if date is in the future" do
       Timecop.freeze("2019-03-22") do
         invalid_fields = validate_date_of_birth("2020", "02", "01", "date")
-        expect(invalid_fields).to eq [{ field: "date-day", text: "Date of birth must be in the past" }]
+        expect(invalid_fields).to eq [{ field: "date-day", text: I18n.t("coronavirus_form.errors.date_order") }]
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/aZdkhCC0

This should make it easier for content designers and others to change content without worrying about breaking tests.