### PR TITLE
Reject date of birth older than 150 years

### DIFF
--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -76,6 +76,10 @@ module FieldValidationHelper
     unless(invalid_fields != [] || DateTime.new(year.to_i, month.to_i, day.to_i) < Time.zone.now)
       invalid_fields << { field: "#{field}-day", text: t("coronavirus_form.errors.date_order") }
     end
+    # Check for date being more than 150 years ago
+    unless(invalid_fields != [] || DateTime.new(year.to_i, month.to_i, day.to_i) >= 150.years.ago)
+      invalid_fields << { field: "#{field}-year", text: t("coronavirus_form.errors.invalid_date") }
+    end
     invalid_fields
   end
 

--- a/spec/helpers/field_validation_helper_spec.rb
+++ b/spec/helpers/field_validation_helper_spec.rb
@@ -2,6 +2,13 @@ require "spec_helper"
 
 RSpec.describe FieldValidationHelper, type: :helper do
   context "#validate_date_of_birth" do
+    it "does not return an error for a valid date" do
+      Timecop.freeze("2019-04-21") do
+        invalid_fields = validate_date_of_birth("1970", "02", "01", "date")
+        expect(invalid_fields).to be_empty
+      end
+    end
+
     it "returns an error if year is blank" do
       invalid_fields = validate_date_of_birth("", "6", "25", "date")
       expect(invalid_fields).to eq [{ field: "date-year", text: I18n.t("coronavirus_form.errors.missing_fields") }]
@@ -69,6 +76,11 @@ RSpec.describe FieldValidationHelper, type: :helper do
         invalid_fields = validate_date_of_birth("2020", "02", "01", "date")
         expect(invalid_fields).to eq [{ field: "date-day", text: I18n.t("coronavirus_form.errors.date_order") }]
       end
+    end
+
+    it "returns an error if date is more than 150 years ago" do
+      invalid_fields = validate_date_of_birth("1869", "02", "01", "date")
+      expect(invalid_fields).to eq [{ field: "date-year", text: I18n.t("coronavirus_form.errors.invalid_date") }]
     end
   end
 end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -60,7 +60,7 @@ module FillInTheFormSteps
     within find(".govuk-main-wrapper") do
       fill_in "date_of_birth-day", with: "1"
       fill_in "date_of_birth-month", with: "1"
-      fill_in "date_of_birth-year", with: "1200"
+      fill_in "date_of_birth-year", with: "1970"
       click_on I18n.t("coronavirus_form.submit_and_next")
     end
   end


### PR DESCRIPTION
Shows an error message if a user enters a date of birth that is more than 150 years into the past.  This will reduce validation errors when the form responses are triaged.

<img width="673" alt="Screenshot 2020-04-21 at 13 47 17" src="https://user-images.githubusercontent.com/6329861/79867746-bddf7600-83d6-11ea-9e95-35ca2d4ee3cc.png">

Trello card: https://trello.com/c/4uOY1kyH