### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+What
+----
+
+Describe what you have changed and why.
+
+How to review
+-------------
+
+:ship: Since this service is continuously deployed, all testing must be done
+before the pull request is merged. :ship:
+
+Describe the steps required to review and test the changes.
+
+Links
+-----
+
+Add links to any relevant [Trello cards](https://trello.com/b/9Pvq5z2n/govuk-coronavirus-services-team-doing-board),
+Zendesk tickets or Sentry issues.
+


### PR DESCRIPTION
What
----

This should help bring a bit of structure to our PRs, and should help to
remind people about the fact that this service is continuously deployed
(which otherwise could trip up new joiners, who might be used to a
different process).

How to review
-------------

* Review the wording of the template, and think about how it will affect people's behaviour when they're raising PRs
* Suggest any improvements or alterations in GitHub comments

Links
-----

* Trello: https://trello.com/c/SUaQNYjY/317-add-pull-request-templates-to-all-three-forms
* Equivalent PR in business-volunteer: https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/258