### PR TITLE
Improve email address validation

### DIFF
--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -84,7 +84,7 @@ module FieldValidationHelper
   end
 
   def validate_email_address(field, email_address)
-    if email_address =~ /@/
+    if email_address =~ /(^[a-zA-Z0-9_.+\-]+@[a-zA-Z0-9\-]+\.[a-zA-Z0-9\-.]+$)/
       []
     else
       [{ field: field.to_s, text: t("coronavirus_form.errors.email_format") }]

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
     end
 
     it "does not move to next step with an invalid email address" do
-      post :submit, params: { "email": "not-a-valid-email" }
+      post :submit, params: { "email": "govuk-coronavirus-services@digital.cabinet_office,gov.uk" }
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end

--- a/spec/helpers/field_validation_helper_spec.rb
+++ b/spec/helpers/field_validation_helper_spec.rb
@@ -105,4 +105,26 @@ RSpec.describe FieldValidationHelper, type: :helper do
       expect(invalid_fields).to eq [{ field: "phone-number", text: I18n.t("coronavirus_form.errors.telephone_number_format") }]
     end
   end
+
+  describe "#validate_email_address" do
+    it "does not return an error for a correctly formatted email address" do
+      invalid_fields = validate_email_address("email_address", "govuk-coronavirus-services@digital.cabinet-office.gov.uk")
+      expect(invalid_fields).to be_empty
+    end
+
+    it "returns an error for an email address containing commas" do
+      invalid_fields = validate_email_address("email_address", "govuk-coronavirus-services@digital.cabinet-office,gov.uk")
+      expect(invalid_fields).to eq [{ field: "email_address", text: I18n.t("coronavirus_form.errors.email_format") }]
+    end
+
+    it "returns an error for an email address containing spaces" do
+      invalid_fields = validate_email_address("email_address", "govuk coronavirus services@digital.cabinet-office.gov.uk")
+      expect(invalid_fields).to eq [{ field: "email_address", text: I18n.t("coronavirus_form.errors.email_format") }]
+    end
+
+    it "returns an error for the email address not containing @" do
+      invalid_fields = validate_email_address("email_address", "some-random-text")
+      expect(invalid_fields).to eq [{ field: "email_address", text: I18n.t("coronavirus_form.errors.email_format") }]
+    end
+  end
 end

--- a/spec/helpers/field_validation_helper_spec.rb
+++ b/spec/helpers/field_validation_helper_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe FieldValidationHelper, type: :helper do
-  context "#validate_date_of_birth" do
+  describe "#validate_date_of_birth" do
     it "does not return an error for a valid date" do
       Timecop.freeze("2019-04-21") do
         invalid_fields = validate_date_of_birth("1970", "02", "01", "date")
@@ -84,7 +84,7 @@ RSpec.describe FieldValidationHelper, type: :helper do
     end
   end
 
-  context "#validate_telephone_number" do
+  describe "#validate_telephone_number" do
     it "does not return an error for a valid UK number" do
       invalid_fields = validate_telephone_number("phone-number", "01234 567 890")
       expect(invalid_fields).to be_empty


### PR DESCRIPTION
- We were previously only validating that the email address contains the
  `@` character. That's not enough, as people can enter invalid email
  addresses, like ones with commas in, if they mistype `.com` or
  somesuch.
- Our downstream data consumers were finding this out the hard way when
  they tried to use the email addresses to contact people.
- This uses the Python implementation at https://emailregex.com/ to
  validate the email address doesn't contain any invalid characters.

https://trello.com/c/hGSi37CH/315-email-address-field-accepts-commas
