### PR TITLE
Remove reference to letter from confirmation page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,9 +213,7 @@ en:
         </ul>
         <p class="govuk-body">If you haven’t had the letter or been contacted by your GP or hospital clinician, contact them as soon as possible and ask them to confirm that you’re classed as clinically extremely vulnerable. You may not get the support you need if you do not contact them.</p>
         <h2 class="govuk-heading-m">What happens next</h2>
-        <p class="govuk-body">We’ll check your details and if you’re eligible to get support, we’ll send you a letter confirming that. The letter may take a few days to come.</p>
-        <h2 class="govuk-heading-m">Getting support</h2>
-        <p class="govuk-body">You’ll only get support if you asked for it.</p>
+        <p class="govuk-body">We'll check your details to make sure you're eligible for support. You’ll only get support if you asked for it.</p>
         <p class="govuk-body">It may take time for you to get support. If you have urgent care or support needs then contact your local authority.</p>
         <p class="govuk-body">Wherever possible you should continue to rely on friends, family and wider support to help you meet your needs.</p>
         <p class="govuk-body">Contact your GP or hospital clinician directly if you have urgent medical needs.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,7 +213,7 @@ en:
         </ul>
         <p class="govuk-body">If you haven’t had the letter or been contacted by your GP or hospital clinician, contact them as soon as possible and ask them to confirm that you’re classed as clinically extremely vulnerable. You may not get the support you need if you do not contact them.</p>
         <h2 class="govuk-heading-m">What happens next</h2>
-        <p class="govuk-body">We'll check your details to make sure you're eligible for support. You’ll only get support if you asked for it.</p>
+        <p class="govuk-body">We’ll check your details to make sure you’re eligible for support. You’ll only get support if you asked for it.</p>
         <p class="govuk-body">It may take time for you to get support. If you have urgent care or support needs then contact your local authority.</p>
         <p class="govuk-body">Wherever possible you should continue to rely on friends, family and wider support to help you meet your needs.</p>
         <p class="govuk-body">Contact your GP or hospital clinician directly if you have urgent medical needs.</p>


### PR DESCRIPTION
This PR removes the reference to the letter from confirmation page

https://trello.com/c/D3QGpz2I/319-remove-reference-to-letter-on-confirmation-page


