### PR TITLE
Validate and reformat telephone numbers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "lograge"
 gem "puma", "~> 4.3"
 gem "sass-rails", "< 6"
 gem "sentry-raven", "~> 3.0"
+gem "telephone_number", "~> 1.4"
 gem "timecop"
 gem "uglifier", "~> 4.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,6 +348,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
+    telephone_number (1.4.6)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -404,6 +405,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven (~> 3.0)
   simplecov (~> 0.16)
+  telephone_number (~> 1.4)
   timecop
   uglifier (~> 4.2)
   webdrivers

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -10,11 +10,11 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
       },
     }
 
-    invalid_fields = if @form_responses[:contact_details].dig(:email)
-                       validate_email_address("email", @form_responses.dig(:contact_details, :email))
-                     else
-                       []
-                     end
+    invalid_fields = [
+      @form_responses[:contact_details].dig(:phone_number_calls) ? validate_telephone_number("phone_number_calls", @form_responses.dig(:contact_details, :phone_number_calls)) : [],
+      @form_responses[:contact_details].dig(:phone_number_texts) ? validate_telephone_number("phone_number_texts", @form_responses.dig(:contact_details, :phone_number_texts)) : [],
+      @form_responses[:contact_details].dig(:email) ? validate_email_address("email", @form_responses.dig(:contact_details, :email)) : [],
+    ].flatten.compact
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -24,15 +24,21 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
-      session[:contact_details] = @form_responses[:contact_details]
+      update_session_store
       redirect_to check_your_answers_url
     else
-      session[:contact_details] = @form_responses[:contact_details]
+      update_session_store
       redirect_to know_nhs_number_url
     end
   end
 
 private
+
+  def update_session_store
+    @form_responses[:contact_details][:phone_number_calls] = TelephoneNumber.parse(@form_responses[:contact_details][:phone_number_calls], :gb).national_number
+    @form_responses[:contact_details][:phone_number_texts] = TelephoneNumber.parse(@form_responses[:contact_details][:phone_number_texts], :gb).national_number
+    session[:contact_details] = @form_responses[:contact_details]
+  end
 
   def previous_path
     support_address_path

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -100,4 +100,12 @@ module FieldValidationHelper
       [{ field: field.to_s, text: t("coronavirus_form.errors.postcode_format") }]
     end
   end
+
+  def validate_telephone_number(field, telephone_number)
+    if TelephoneNumber.parse(telephone_number, :gb).valid?
+      []
+    else
+      [{ field: field.to_s, text: t("coronavirus_form.errors.telephone_number_format") }]
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,7 @@ en:
       postcode_format: "Enter a real postcode"
       negative_date: "Enter a real %{field}"
       date_not_a_number: "Enter %{field} as a number"
+      telephone_number_format: "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192"
     confirmation:
       title: Registration complete
       description: |

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -21,16 +21,16 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
   describe "POST submit" do
     let(:params) do
       {
-        "phone_number_calls" => "01234 578 890<script></script>",
-        "phone_number_texts" => "01876 543 210",
+        "phone_number_calls" => "01234-578-890<script></script>",
+        "phone_number_texts" => "+44(0)1876 543 210",
         "email" => "<script></script>tester@example.org",
       }
     end
 
     let(:contact_details) do
       {
-        phone_number_calls: "01234 578 890",
-        phone_number_texts: "01876 543 210",
+        phone_number_calls: "01234 578890",
+        phone_number_texts: "01876 543210",
         email: "tester@example.org",
       }
     end
@@ -47,8 +47,8 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       }
 
       contact_details = {
-        phone_number_calls: "01234567890",
-        phone_number_texts: "01234567890",
+        phone_number_calls: "01234 567890",
+        phone_number_texts: "01234 567890",
         email: nil,
       }
 

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -21,16 +21,16 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
   describe "POST submit" do
     let(:params) do
       {
-        "phone_number_calls" => "1234<script></script>",
-        "phone_number_texts" => "5678",
+        "phone_number_calls" => "01234 578 890<script></script>",
+        "phone_number_texts" => "01876 543 210",
         "email" => "<script></script>tester@example.org",
       }
     end
 
     let(:contact_details) do
       {
-        phone_number_calls: "1234",
-        phone_number_texts: "5678",
+        phone_number_calls: "01234 578 890",
+        phone_number_texts: "01876 543 210",
         email: "tester@example.org",
       }
     end
@@ -42,13 +42,13 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
 
     it "strips html characters" do
       params = {
-        "phone_number_calls" => '<a href="https://www.example.com">Link</a>',
-        "phone_number_texts" => '<a href="https://www.example.com">Link</a>',
+        "phone_number_calls" => '<a href="https://www.example.com">01234567890</a>',
+        "phone_number_texts" => '<a href="https://www.example.com">01234567890</a>',
       }
 
       contact_details = {
-        phone_number_calls: "Link",
-        phone_number_texts: "Link",
+        phone_number_calls: "01234567890",
+        phone_number_texts: "01234567890",
         email: nil,
       }
 
@@ -59,6 +59,18 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
     it "redirects to next step for a permitted response" do
       post :submit, params: params
       expect(response).to redirect_to(know_nhs_number_path)
+    end
+
+    it "does not move to next step with an invalid phone number for calls" do
+      post :submit, params: { "phone_number_calls": "1234" }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(current_template)
+    end
+
+    it "does not move to next step with an invalid phone number for text messages" do
+      post :submit, params: { "phone_number_calls": "1234" }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(current_template)
     end
 
     it "does not move to next step with an invalid email address" do

--- a/spec/helpers/field_validation_helper_spec.rb
+++ b/spec/helpers/field_validation_helper_spec.rb
@@ -83,4 +83,26 @@ RSpec.describe FieldValidationHelper, type: :helper do
       expect(invalid_fields).to eq [{ field: "date-year", text: I18n.t("coronavirus_form.errors.invalid_date") }]
     end
   end
+
+  context "#validate_telephone_number" do
+    it "does not return an error for a valid UK number" do
+      invalid_fields = validate_telephone_number("phone-number", "01234 567 890")
+      expect(invalid_fields).to be_empty
+    end
+
+    it "returns an error if number is too short" do
+      invalid_fields = validate_telephone_number("phone-number", "01234 567 89")
+      expect(invalid_fields).to eq [{ field: "phone-number", text: I18n.t("coronavirus_form.errors.telephone_number_format") }]
+    end
+
+    it "returns an error if number is too long" do
+      invalid_fields = validate_telephone_number("phone-number", "01234 567 8900")
+      expect(invalid_fields).to eq [{ field: "phone-number", text: I18n.t("coronavirus_form.errors.telephone_number_format") }]
+    end
+
+    it "returns an error if number is not a UK number" do
+      invalid_fields = validate_telephone_number("phone-number", "+353 1 234 5670")
+      expect(invalid_fields).to eq [{ field: "phone-number", text: I18n.t("coronavirus_form.errors.telephone_number_format") }]
+    end
+  end
 end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -80,8 +80,8 @@ module FillInTheFormSteps
   def and_has_given_their_contact_details
     expect(page.body).to have_content(I18n.t("coronavirus_form.questions.contact_details.title"))
     within find(".govuk-main-wrapper") do
-      fill_in "phone_number_calls", with: "07000000000"
-      fill_in "phone_number_texts", with: "07000000000"
+      fill_in "phone_number_calls", with: "01234567890"
+      fill_in "phone_number_texts", with: "01234567890"
       fill_in "email", with: Rails.application.config.courtesy_copy_email
       click_on I18n.t("coronavirus_form.submit_and_next")
     end


### PR DESCRIPTION
What
----
Implements telephone number validation for the contact details question.

Using the `telephone_number` gem, the following are validated:
- The number matches a regular expression for UK phone numbers
- The number is the correct length for the area code provided
- If an international dialling code is added, this must be `+44`
- The area code is a valid area code
- All formatting entered by the user (e.g. parentheses, dashes and spaces) are ignored for the validation

The telephone number fields remain optional, so no validation is carried out if the entry is blank.

If an invalid number is specified, an error is displayed, as specified in the GOV.UK Design System.
<img width="517" alt="Screenshot 2020-04-23 at 09 24 47" src="https://user-images.githubusercontent.com/6329861/80086547-c90ae100-8551-11ea-92b4-5e8600eaf631.png">

For a valid telephone number, we then use the `telephone_number` gem to correctly format the number as a UK national number to maintain consistency for downstream data consumers, e.g.
- `+44(0)1234567890` would become `01234 567890`
- `01141001000` would become `0114 100 1000`

How to review
-------------

- Review code changes.
- Manually test the functionality by running the app locally, navigating to localhost:5000/contact-details, entering valid/invalid telephone numbers to examine behaviour.  Visit localhost:5000/check-your-answers to see behaviour of telephone number reformatting.

Links
-----

Trello card: https://trello.com/c/QSr0txcr