### PR TITLE
ci: Trim GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,6 @@ jobs:
       env:
         RAILS_ENV: test
       run: |
-        gem install bundler
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
 


### PR DESCRIPTION
What
----

This shortens the GitHub Actions runtime slightly, because Ruby 2.6 already ships with Bundler.

How to review
-------------

See the CI build go green.

Links
-----

n/a

