### PR TITLE
Add Action to automatically label content changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+content-change:
+  - config/locales/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+
+on: pull_request
+
+jobs:
+  label_things:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## What

Adds an GitHub Action that labels a pull request with the `content-change` label if the internationalisation files are changed. We can expand this to encompass other changes by editing the `labeler.yml` file in the `.github` folder.

## Why

So we can clearly see what pull requests have a content change in them and to demonstrate a simple GitHub Actions automation.

