### PR TITLE
WIP: allow user to be referred from another application

### DIFF
--- a/app/controllers/coronavirus_form/refer_from_other_app_controller.rb
+++ b/app/controllers/coronavirus_form/refer_from_other_app_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::ReferFromOtherAppController < ApplicationController
+  def from_find_support_app
+    ## Sets the session variables that the user would have already answered in Support app
+    session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
+    session[:nhs_letter] = I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
+    session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_medical.label")
+    # TODO: this may need to be a POST request since the medical conditions question has multiple "yes" responses
+
+    # Redirect to next question
+    redirect_to name_url
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
 
     get "/session-expired", to: "session_expired#show"
 
+    get "/refer-from-find-support", to: "refer_from_other_app#from_find_support_app"
+
     # Question 1.0: Do you live in England?
     get "/live-in-england", to: "live_in_england#show"
     post "/live-in-england", to: "live_in_england#submit"


### PR DESCRIPTION
This allows them to skip questions they would have already answered in
the find support (triage) tool

What
----

Describe what you have changed and why.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

Links
-----

Add links to any relevant [Trello cards](https://trello.com/b/9Pvq5z2n/govuk-coronavirus-services-team-doing-board),
Zendesk tickets or Sentry issues.

