### PR TITLE
ci: Get the Ruby version from `.ruby-version`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Ruby 2.6.5
-      uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.5
+        ruby-version: .ruby-version
 
     - uses: actions/cache@v1
       with:


### PR DESCRIPTION
What
----

The CI pipeline now pulls the Ruby version to install from the `.ruby-version` file in this repo.

It would have been annoying to have to update the Ruby version in multiple places next time there's a new one.

How to review
-------------

Observe that CI passes, still running Ruby 2.6.5.

Links
-----

n/a

