### PR TITLE
ci: Oops, pulling the Ruby version from `.ruby-version` is the default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-
     - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: .ruby-version
 
     - uses: actions/cache@v1
       with:


### PR DESCRIPTION
What
----

Simplicity. We can use the [defaults](https://github.com/ruby/setup-ruby#supported-version-syntax) of the `ruby/setup-ruby` Action, and slim down our tests.yml file - again...

How to review
-------------

Observe that CI still runs under 2.6.5.

Links
-----

n/a

