### PR TITLE
Always store date of birth in the same format

### DIFF
--- a/app/controllers/coronavirus_form/date_of_birth_controller.rb
+++ b/app/controllers/coronavirus_form/date_of_birth_controller.rb
@@ -25,15 +25,29 @@ class CoronavirusForm::DateOfBirthController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
-      session[:date_of_birth] = @form_responses[:date_of_birth]
+      update_session_store
       redirect_to check_your_answers_url
     else
-      session[:date_of_birth] = @form_responses[:date_of_birth]
+      update_session_store
       redirect_to support_address_url
     end
   end
 
 private
+
+  def update_session_store
+    date_of_birth = DateTime.new(
+      @form_responses[:date_of_birth].dig(:year).to_i,
+      @form_responses[:date_of_birth].dig(:month).to_i,
+      @form_responses[:date_of_birth].dig(:day).to_i,
+    )
+
+    session[:date_of_birth] = {
+      year: date_of_birth.strftime("%Y"),
+      month: date_of_birth.strftime("%m"),
+      day: date_of_birth.strftime("%d"),
+      }
+  end
 
   def previous_path
     name_path

--- a/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
     let(:date_of_birth) do
       {
         day: "31",
-        month: "1",
+        month: "01",
         year: "1980",
       }
     end


### PR DESCRIPTION
What
----

We have found some users enter date of births in differing formats, which can cause confusion, or errors, in the downstream processing.

Therefore ensuring that the year is always stored with 4 digits (e.g. to avoid confusion whether 01 is 1901 or 2001), the month and day will always be two digits.

How to review
-------------

App link: https://coronavirus-improve-dob-fatgec.herokuapp.com/live-in-england

- Review code.
- Run app locally, or in Heroku review.  Navigate to `/date-of-birth`.  Try various dates, but specifically those with a single digit for the day or month.  Then go to `/check-your-answers`.  You should see the dates padded with a leading zero, which will be the format we save the data.

Links
-----

Trello card: https://trello.com/c/S5XTLtzH