### PR TITLE
Bugfix: return valid error message for large numbers

### DIFF
--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -81,6 +81,8 @@ module FieldValidationHelper
       invalid_fields << { field: "#{field}-year", text: t("coronavirus_form.errors.invalid_date") }
     end
     invalid_fields
+  rescue RangeError
+    [{ field: field, text: t("coronavirus_form.errors.invalid_date") }]
   end
 
   def validate_email_address(field, email_address)

--- a/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/date_of_birth_controller_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe CoronavirusForm::DateOfBirthController, type: :controller do
       post :submit, params: {
         "date_of_birth" => {
           "day" => "<script></script>31",
-          "month" => "</script>123456789 not a number",
-          "year" => "not a number",
+          "month" => "</script>11111111111",
+          "year" => "11111111111",
         },
       }
       expect(response).to have_http_status(:unprocessable_entity)


### PR DESCRIPTION
Fixes https://sentry.io/organizations/govuk/issues/1580673537
https://trello.com/c/65IWRTkm/340-fix-rangeerror

If a user gives us a huge number e.g. 99999999999 we should return a 422 error, since no number that large would be a valid date.

Currently we return a 500 error since `Date.valid_date?` raises a `RangeError` when given a large enough number. I'm not sure why in this case since `99999999999.to_i.class == Integer`.

I think it's because of a bug (behaviour) in the [valid_date?](https://apidock.com/ruby/Date/valid_date%3F/class) method that [raises a RangeError](https://github.com/ruby/ruby/blob/1a4f33e84e0633e8f953ee3cb06b42dcc952444a/numeric.c#L2935). It should just return false in this case.

Now we return a validation error rather than a 500:

<img width="693" alt="Screenshot 2020-04-28 at 19 34 03" src="https://user-images.githubusercontent.com/8124374/80526141-366fa500-898a-11ea-8bd8-a46d5dcb6c44.png">
