### PR TITLE
Prometheus instrumentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ Metrics/BlockLength:
   Exclude:
     - config/**/*
 
+Rails/HttpPositionalArguments:
+  Exclude:
+    - spec/requests/**/*
+
 Style/WordArray:
   Exclude:
     - config/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "telephone_number", "~> 1.4"
 gem "timecop"
 gem "uglifier", "~> 4.2"
 
+gem "prometheus-client", "~> 2.0"
+
 group :development do
   gem "listen", "~> 3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,7 @@ GEM
     parser (2.7.1.1)
       ast (~> 2.4.0)
     plek (3.0.0)
+    prometheus-client (2.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -394,6 +395,7 @@ DEPENDENCIES
   listen (~> 3)
   lograge
   mini_racer (~> 0.2)
+  prometheus-client (~> 2.0)
   pry (~> 0.13.1)
   pry-rails (~> 0.3.9)
   puma (~> 4.3)

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -22,6 +22,8 @@ params:
   BASIC_AUTH_PASSWORD:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
+  METRICS_USERNAME: ((metrics-username))
+  METRICS_PASSWORD: ((metrics-password))
 run:
   dir: src
   path: sh
@@ -51,6 +53,8 @@ run:
       cf set-env govuk-coronavirus-vulnerable-people-form AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
       cf set-env govuk-coronavirus-vulnerable-people-form SECRET_KEY_BASE "$SECRET_KEY_BASE"
       cf set-env govuk-coronavirus-vulnerable-people-form GA_VIEW_ID "$GA_VIEW_ID"
+      cf set-env govuk-coronavirus-vulnerable-people-form METRICS_USERNAME "$METRICS_USERNAME"
+      cf set-env govuk-coronavirus-vulnerable-people-form METRICS_PASSWORD "$METRICS_PASSWORD"
 
       cf v3-zdt-push govuk-coronavirus-vulnerable-people-form --wait-for-deploy-complete --no-route
       cf map-route govuk-coronavirus-vulnerable-people-form cloudapps.digital --hostname "$HOSTNAME"

--- a/concourse/tasks/run-smoke-tests.yml
+++ b/concourse/tasks/run-smoke-tests.yml
@@ -7,6 +7,8 @@ image_resource:
 params:
   TEST_URL:
   RAILS_ENV: smoke_test
+  METRICS_USERNAME: ((metrics-username))
+  METRICS_PASSWORD: ((metrics-password))
 inputs:
   - name: git-master
 run:

--- a/config.ru
+++ b/config.ru
@@ -3,5 +3,8 @@
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'
+require_relative 'helpers/application_config'
 
-run Rails.application
+rackapp = ApplicationConfig.call
+
+run rackapp

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,8 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.metrics_username = ENV["METRICS_USERNAME"] || "username"
+
+  config.metrics_password = ENV["METRICS_PASSWORD"] || "password"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,4 +120,7 @@ Rails.application.configure do
   #   ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context =
   #   ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.metrics_username = ENV["METRICS_USERNAME"]
+  config.metrics_password = ENV["METRICS_PASSWORD"]
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,10 @@ Rails.application.configure do
 
   config.analytics_tracking_id = "12345"
 
+  config.metrics_username = ENV["METRICS_USERNAME"] || "username"
+
+  config.metrics_password = ENV["METRICS_PASSWORD"] || "password"
+
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 end

--- a/helpers/application_config.rb
+++ b/helpers/application_config.rb
@@ -1,0 +1,21 @@
+require "prometheus/middleware/collector"
+require "prometheus/middleware/exporter"
+
+class ApplicationConfig
+  def self.call
+    Rack::Builder.app do
+      use Prometheus::Middleware::Collector
+
+      map "/metrics" do
+        use Rack::Auth::Basic, "Prometheus Metrics" do |username, password|
+          Rack::Utils.secure_compare(Rails.application.config.metrics_username, username) && Rack::Utils.secure_compare(Rails.application.config.metrics_password, password)
+        end
+        use Rack::Deflater
+        use Prometheus::Middleware::Exporter, path: ""
+        run ->(_) { [500, { "Content-Type" => "text/html" }, ["Metrics endpoint is unreachable!"]] }
+      end
+
+      run Rails.application
+    end
+  end
+end

--- a/spec/requests/view_metrics_spec.rb
+++ b/spec/requests/view_metrics_spec.rb
@@ -1,0 +1,31 @@
+require_relative "../../helpers/application_config"
+require "rack/test"
+require "spec_helper"
+
+RSpec.describe "prometheus metrics", type: :request do
+  include Rack::Test::Methods
+
+  rack_app = ApplicationConfig.call
+
+  let(:app) do
+    rack_app
+  end
+
+  context "when requesting app endpoints" do
+    it "returns ok response" do
+      username = Rails.application.config.metrics_username
+      password = Rails.application.config.metrics_password
+
+      get "/metrics", {}, { "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password) }
+
+      expect(last_response).to be_ok
+    end
+
+    it "returns forbidden response without authentication" do
+      get "/metrics"
+
+      expect(last_response).not_to be_ok
+      expect(last_response.status).to eq(401)
+    end
+  end
+end


### PR DESCRIPTION
What
----

Set up Prometheus /metrics endpoint with basic auth

- This will be scraped by the gds-prometheus service broker in PaaS
- These metrics will appear in the prom1 prometheus service, run by RE

Links
-----

[Trello](https://trello.com/c/AM0i3vq8/337-instrument-vulnerable-people-service)

Co-authored-by: Bill Franklin <william.franklin@digital.cabinet-office.gov.uk>

