### PR TITLE
Bind service prometheus-service-broker to app

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,6 +6,7 @@ applications:
   services:
   - logit-ssl-drain
   - splunk-ssl-drain
+  - prometheus-service-broker
   env:
     GOVUK_APP_DOMAIN: cloudapps.digital
     GOVUK_WEBSITE_ROOT: www.gov.uk


### PR DESCRIPTION
I've ensured the service is named consistently in staging and production.

https://reliability-engineering.cloudapps.digital/monitoring-alerts.html#bind-your-exporter-to-prometheus

https://trello.com/c/AM0i3vq8/337-instrument-vulnerable-people-service
