### PR TITLE
Update cookie name in privacy policy

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,7 +70,7 @@ en:
             - - text: cookie_preferences
               - text: Let us know what your cookie preferences are.
               - text: 1 year
-            - - text: _sessions_store
+            - - text: _session_id
               - text: Remembers which question you’re up to and how you answered previous questions.
               - text: 4 hours
         - header: Measuring website usage (Google Analytics)


### PR DESCRIPTION
The session cookie name in the privacy policy was incorrect.  We are using cookie based sessions in this app, which uses the cookie name `_session_id` (rather than the Redis based business support app, which is `_sessions_store`).