### PR TITLE
Remove basic auth from /metrics

### DIFF
--- a/helpers/application_config.rb
+++ b/helpers/application_config.rb
@@ -7,9 +7,6 @@ class ApplicationConfig
       use Prometheus::Middleware::Collector
 
       map "/metrics" do
-        use Rack::Auth::Basic, "Prometheus Metrics" do |username, password|
-          Rack::Utils.secure_compare(Rails.application.config.metrics_username, username) && Rack::Utils.secure_compare(Rails.application.config.metrics_password, password)
-        end
         use Rack::Deflater
         use Prometheus::Middleware::Exporter, path: ""
         run ->(_) { [500, { "Content-Type" => "text/html" }, ["Metrics endpoint is unreachable!"]] }

--- a/spec/requests/view_metrics_spec.rb
+++ b/spec/requests/view_metrics_spec.rb
@@ -13,19 +13,9 @@ RSpec.describe "prometheus metrics", type: :request do
 
   context "when requesting app endpoints" do
     it "returns ok response" do
-      username = Rails.application.config.metrics_username
-      password = Rails.application.config.metrics_password
-
-      get "/metrics", {}, { "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password) }
-
-      expect(last_response).to be_ok
-    end
-
-    it "returns forbidden response without authentication" do
       get "/metrics"
 
-      expect(last_response).not_to be_ok
-      expect(last_response.status).to eq(401)
+      expect(last_response).to be_ok
     end
   end
 end


### PR DESCRIPTION
We don't have a way of giving prometheus a username/password so we've created routes with an ip safelist service in front of them to our metrics endpoint.

https://trello.com/c/AM0i3vq8/337-instrument-vulnerable-people-service

Co-Authored-By: @Rosa-Fox 