### PR TITLE
Say why it's helpful to provide NHS number

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,7 +363,7 @@ en:
           <br /><br />
           You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service.
           <br /><br />
-          Don’t worry if you cannot find it. You’ll still be able to register.
+          If you do not provide an NHS number it may delay support getting to you.
         options:
           option_yes:
             label: "Yes, I know my NHS number"


### PR DESCRIPTION
We want to encourage people to provide an NHS number because it makes matching easier. Updated hint text to clarify why it's a good idea to provide your NHS number if possible.

https://trello.com/c/cz9sBWWX/365-change-wording-around-nhs-number-on-form