### PR TITLE
Send confirmation SMS on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You'll need to pass a GOV.UK Notify API key as an environment variable
 config.action_mailer.delivery_method = :notify
 ```
 
-You'll also need to set a `GOVUK_NOTIFY_TEMPLATE_ID`, which might involve
+You'll also need to set a `GOVUK_NOTIFY_EMAIL_TEMPLATE_ID`, which might involve
 creating a template in Notify if your Notify service doesn't have one.
 
 The template should have a Message of `((body))` only.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You'll need to pass a GOV.UK Notify API key as an environment variable
 `NOTIFY_API_KEY`, and change the delivery method in [development.rb][]:
 
 ```ruby
-config.action_mailer.delivery_method = :notify
+config.action_mailer.delivery_method = :notify_email
 ```
 
 You'll also need to set a `GOVUK_NOTIFY_EMAIL_TEMPLATE_ID`, which might involve

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ to process the email queue.
 Sidekiq will start automatically when you run `foreman start`, but you can
 also run it alone with `bundle exec sidekiq`.
 
-#### Sending emails locally
+#### Sending emails or SMSs locally
 
 You'll need to pass a GOV.UK Notify API key as an environment variable
 `NOTIFY_API_KEY`, and change the delivery method in [development.rb][]:
@@ -60,8 +60,9 @@ You'll need to pass a GOV.UK Notify API key as an environment variable
 config.action_mailer.delivery_method = :notify_email
 ```
 
-You'll also need to set a `GOVUK_NOTIFY_EMAIL_TEMPLATE_ID`, which might involve
-creating a template in Notify if your Notify service doesn't have one.
+You'll also need to set a `GOVUK_NOTIFY_EMAIL_TEMPLATE_ID` and
+`GOVUK_NOTIFY_SMS_TEMPLATE_ID`, which might involve creating a
+template in Notify if your Notify service doesn't have one.
 
 The template should have a Message of `((body))` only.
 

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -48,7 +48,8 @@ private
 
   def smoke_tester?
     email = session_with_indifferent_access.dig(:contact_details, :email)
-    email.present? && email == Rails.application.config.courtesy_copy_email
+    mobile_number = session_with_indifferent_access.dig(:contact_details, :phone_number_texts)
+    (email.present? && email == Rails.application.config.courtesy_copy_email) || (mobile_number.present? && mobile_number == Rails.application.config.test_telephone_number)
   end
 
   def reference_number

--- a/app/mailers/coronavirus_form_mailer.rb
+++ b/app/mailers/coronavirus_form_mailer.rb
@@ -11,4 +11,12 @@ class CoronavirusFormMailer < ApplicationMailer
       delivery_method: :notify_email,
     )
   end
+
+  def confirmation_sms(telephone_number)
+    @reference_number = params[:reference_number]
+    mail(
+      to: telephone_number,
+      delivery_method: :notify_sms,
+    )
+  end
 end

--- a/app/mailers/coronavirus_form_mailer.rb
+++ b/app/mailers/coronavirus_form_mailer.rb
@@ -13,6 +13,8 @@ class CoronavirusFormMailer < ApplicationMailer
   end
 
   def confirmation_sms(telephone_number)
+    @first_name = params[:first_name]
+    @last_name = params[:last_name]
     @reference_number = params[:reference_number]
     mail(
       to: telephone_number,

--- a/app/mailers/coronavirus_form_mailer.rb
+++ b/app/mailers/coronavirus_form_mailer.rb
@@ -5,6 +5,10 @@ class CoronavirusFormMailer < ApplicationMailer
     @first_name = params[:first_name]
     @last_name = params[:last_name]
     @reference_number = params[:reference_number]
-    mail(to: email_address, subject: I18n.t("emails.confirmation.subject"))
+    mail(
+      to: email_address,
+      subject: I18n.t("emails.confirmation.subject"),
+      delivery_method: :notify_email,
+    )
   end
 end

--- a/app/views/coronavirus_form_mailer/confirmation_sms.text.erb
+++ b/app/views/coronavirus_form_mailer/confirmation_sms.text.erb
@@ -1,0 +1,1 @@
+<%= t("sms.confirmation.body_text", first_name: @first_name, last_name: @last_name, reference_number: @reference_number) %>

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -109,6 +109,7 @@ jobs:
           AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-vulnerable-people-assets-staging
           HOSTNAME: govuk-coronavirus-vulnerable-people-form-stg
           GOVUK_NOTIFY_EMAIL_TEMPLATE_ID: d4fddfce-1dfd-4ff5-ab42-156e6ba3e76b
+          GOVUK_NOTIFY_SMS_TEMPLATE_ID: a2166a39-91f5-4370-bbbf-c59276975d49
           NOTIFY_API_KEY: ((notify-api-key-stg))
 
   - name: smoke-test-staging
@@ -150,6 +151,7 @@ jobs:
           AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-vulnerable-people-assets-prod
           HOSTNAME: govuk-coronavirus-vulnerable-people-form-prod
           GOVUK_NOTIFY_EMAIL_TEMPLATE_ID: eb9f351c-f314-47e4-ba7b-656137521f74
+          GOVUK_NOTIFY_SMS_TEMPLATE_ID: 0480c4b5-4e08-4598-b2c1-bbc99990afc2
           NOTIFY_API_KEY: ((notify-api-key-prod))
 
   - name: smoke-test-prod

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -108,7 +108,7 @@ jobs:
           AWS_DYNAMODB_SUBMISSIONS_TABLE_NAME: coronavirus-vulnerable-people-staging
           AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-vulnerable-people-assets-staging
           HOSTNAME: govuk-coronavirus-vulnerable-people-form-stg
-          GOVUK_NOTIFY_TEMPLATE_ID: d4fddfce-1dfd-4ff5-ab42-156e6ba3e76b
+          GOVUK_NOTIFY_EMAIL_TEMPLATE_ID: d4fddfce-1dfd-4ff5-ab42-156e6ba3e76b
           NOTIFY_API_KEY: ((notify-api-key-stg))
 
   - name: smoke-test-staging
@@ -149,7 +149,7 @@ jobs:
           AWS_DYNAMODB_SUBMISSIONS_TABLE_NAME: coronavirus-vulnerable-people-prod
           AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-vulnerable-people-assets-prod
           HOSTNAME: govuk-coronavirus-vulnerable-people-form-prod
-          GOVUK_NOTIFY_TEMPLATE_ID: eb9f351c-f314-47e4-ba7b-656137521f74
+          GOVUK_NOTIFY_EMAIL_TEMPLATE_ID: eb9f351c-f314-47e4-ba7b-656137521f74
           NOTIFY_API_KEY: ((notify-api-key-prod))
 
   - name: smoke-test-prod

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -25,7 +25,7 @@ params:
   AWS_SECRET_ACCESS_KEY:
   METRICS_USERNAME: ((metrics-username))
   METRICS_PASSWORD: ((metrics-password))
-  GOVUK_NOTIFY_TEMPLATE_ID:
+  GOVUK_NOTIFY_EMAIL_TEMPLATE_ID:
   NOTIFY_API_KEY:
   ORDNANCE_SURVEY_PLACES_API_KEY: ((ordnance-survey-places-api-key))
 run:
@@ -60,7 +60,7 @@ run:
       cf set-env govuk-coronavirus-vulnerable-people-form GA_VIEW_ID "$GA_VIEW_ID"
       cf set-env govuk-coronavirus-vulnerable-people-form METRICS_USERNAME "$METRICS_USERNAME"
       cf set-env govuk-coronavirus-vulnerable-people-form METRICS_PASSWORD "$METRICS_PASSWORD"
-      cf set-env govuk-coronavirus-vulnerable-people-form GOVUK_NOTIFY_TEMPLATE_ID "$GOVUK_NOTIFY_TEMPLATE_ID"
+      cf set-env govuk-coronavirus-vulnerable-people-form GOVUK_NOTIFY_EMAIL_TEMPLATE_ID "$GOVUK_NOTIFY_EMAIL_TEMPLATE_ID"
       cf set-env govuk-coronavirus-vulnerable-people-form NOTIFY_API_KEY "$NOTIFY_API_KEY"
       cf set-env govuk-coronavirus-vulnerable-people-form PAAS_ENV "$CF_SPACE"
 

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -26,6 +26,7 @@ params:
   METRICS_USERNAME: ((metrics-username))
   METRICS_PASSWORD: ((metrics-password))
   GOVUK_NOTIFY_EMAIL_TEMPLATE_ID:
+  GOVUK_NOTIFY_SMS_TEMPLATE_ID:
   NOTIFY_API_KEY:
   ORDNANCE_SURVEY_PLACES_API_KEY: ((ordnance-survey-places-api-key))
 run:
@@ -61,6 +62,7 @@ run:
       cf set-env govuk-coronavirus-vulnerable-people-form METRICS_USERNAME "$METRICS_USERNAME"
       cf set-env govuk-coronavirus-vulnerable-people-form METRICS_PASSWORD "$METRICS_PASSWORD"
       cf set-env govuk-coronavirus-vulnerable-people-form GOVUK_NOTIFY_EMAIL_TEMPLATE_ID "$GOVUK_NOTIFY_EMAIL_TEMPLATE_ID"
+      cf set-env govuk-coronavirus-vulnerable-people-form GOVUK_NOTIFY_SMS_TEMPLATE_ID "$GOVUK_NOTIFY_SMS_TEMPLATE_ID"
       cf set-env govuk-coronavirus-vulnerable-people-form NOTIFY_API_KEY "$NOTIFY_API_KEY"
       cf set-env govuk-coronavirus-vulnerable-people-form PAAS_ENV "$CF_SPACE"
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ module CoronavirusForm
     # the framework and any gems in your application.
 
     config.courtesy_copy_email = "coronavirus-services-smoke-tests@digital.cabinet-office.gov.uk"
+    config.test_telephone_number = "01234567890"
 
     config.active_job.queue_adapter = :sidekiq
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -140,5 +140,5 @@ Rails.application.configure do
     end
   end
 
-  config.action_mailer.delivery_method = :notify
+  config.action_mailer.delivery_method = :notify_email
 end

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -3,4 +3,4 @@ require "notify_delivery_method"
 ActionMailer::Base.add_delivery_method :notify,
                                        NotifyDeliveryMethod,
                                        api_key: Rails.application.secrets.notify_api_key,
-                                       template_id: ENV["GOVUK_NOTIFY_TEMPLATE_ID"]
+                                       template_id: ENV["GOVUK_NOTIFY_EMAIL_TEMPLATE_ID"]

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,6 +1,6 @@
-require "notify_delivery_method"
+require "notify_email_delivery_method"
 
-ActionMailer::Base.add_delivery_method :notify,
-                                       NotifyDeliveryMethod,
+ActionMailer::Base.add_delivery_method :notify_email,
+                                       NotifyEmailDeliveryMethod,
                                        api_key: Rails.application.secrets.notify_api_key,
                                        template_id: ENV["GOVUK_NOTIFY_EMAIL_TEMPLATE_ID"]

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,6 +1,12 @@
 require "notify_email_delivery_method"
+require "notify_sms_delivery_method"
 
 ActionMailer::Base.add_delivery_method :notify_email,
                                        NotifyEmailDeliveryMethod,
                                        api_key: Rails.application.secrets.notify_api_key,
                                        template_id: ENV["GOVUK_NOTIFY_EMAIL_TEMPLATE_ID"]
+
+ActionMailer::Base.add_delivery_method :notify_sms,
+                                       NotifySmsDeliveryMethod,
+                                       api_key: Rails.application.secrets.notify_api_key,
+                                       template_id: ENV["GOVUK_NOTIFY_SMS_TEMPLATE_ID"]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,6 +192,22 @@ en:
 
       <h2 class="govuk-heading-m">If you didn’t expect to see this page</h2>
       <p class="govuk-body">You may be seeing this page because you’ve turned off cookies in your browser. You’ll need to <a class="govuk-link" href="https://ico.org.uk/your-data-matters/online/cookies/" rel="external" target="_blank">turn cookies on</a> before you can use this service.</p>
+  sms:
+    confirmation:
+      body_text: |
+        We’ve received your registration as someone who’s clinically extremely vulnerable to coronavirus.
+
+        You do not need to do anything else if you’ve had a letter from the NHS or your doctor confirming that you’re clinically extremely vulnerable.
+
+        If you haven’t had a letter, contact your GP as soon as possible. Otherwise you may not get support.
+
+        We’ll check that you’re eligible, then you’ll start getting support if you asked for it.
+
+        This can take up to a week, or longer if you haven't had the letter from your NHS or from your doctor. Contact your local authority if you need urgent support and can’t rely on friends or neighbours.
+
+        If you want priority supermarket deliveries and do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
+
+        If your needs change, go to https://www.gov.uk/coronavirus-extremely-vulnerable and answer the questions again.
   emails:
     confirmation:
       subject: "Coronavirus support service: your registration"

--- a/lib/notify_email_delivery_method.rb
+++ b/lib/notify_email_delivery_method.rb
@@ -1,6 +1,6 @@
 require "notifications/client"
 
-class NotifyDeliveryMethod
+class NotifyEmailDeliveryMethod
   attr_reader :settings
 
   def initialize(settings)

--- a/lib/notify_sms_delivery_method.rb
+++ b/lib/notify_sms_delivery_method.rb
@@ -1,0 +1,29 @@
+require "notifications/client"
+
+class NotifySmsDeliveryMethod
+  attr_reader :settings
+
+  def initialize(settings)
+    @settings = settings
+  end
+
+  def deliver!(mail)
+    client.send_sms(payload(mail))
+  end
+
+private
+
+  def client
+    @client ||= Notifications::Client.new(settings[:api_key])
+  end
+
+  def payload(mail)
+    {
+      phone_number: mail.to.first,
+      template_id: settings[:template_id],
+      personalisation: {
+        message: mail.body.raw_source,
+      },
+    }
+  end
+end

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -127,8 +127,17 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
       expect(FormResponse.last.attributes.dig(:FormResponse, :medical_conditions)).to eq("Yes, I have one of the medical conditions on the list")
     end
 
-    it "doesn't create a FormResponse if the user is the smoke tester" do
+    it "doesn't create a FormResponse if the user is the smoke tester identidied by email" do
       session[:contact_details] = { email: Rails.application.config.courtesy_copy_email }
+      session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_gp.label")
+
+      expect {
+        post :submit
+      }.to_not(change { FormResponse.count })
+    end
+
+    it "doesn't create a FormResponse if the user is the smoke tester identidied by mobile telephone number" do
+      session[:contact_details] = { phone_number_texts: Rails.application.config.test_telephone_number }
       session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_gp.label")
 
       expect {

--- a/spec/mailers/coronavirus_form_mailer_spec.rb
+++ b/spec/mailers/coronavirus_form_mailer_spec.rb
@@ -22,14 +22,14 @@ RSpec.describe CoronavirusFormMailer, type: :mailer do
   describe "#confirmation_sms" do
     let(:mail) { CoronavirusFormMailer.with(params).confirmation_sms(to_number) }
     let(:to_number) { "07700900000" }
-    let(:params) { { reference_number: "ABC123" } }
+    let(:params) { { first_name: "John", last_name: "Smith", reference_number: "ABC123" } }
 
     it "renders the headers" do
       expect(mail.to).to eq([to_number])
     end
 
-    it "includes the reference" do
-      expect(mail.body.encoded).to include(params.dig(:reference_number))
+    it "renders the body" do
+      expect(mail.body.encoded).to include("We’ve received your registration")
     end
   end
 end

--- a/spec/mailers/coronavirus_form_mailer_spec.rb
+++ b/spec/mailers/coronavirus_form_mailer_spec.rb
@@ -18,4 +18,18 @@ RSpec.describe CoronavirusFormMailer, type: :mailer do
       expect(mail.body.encoded).to include(params.dig(:reference_number))
     end
   end
+
+  describe "#confirmation_sms" do
+    let(:mail) { CoronavirusFormMailer.with(params).confirmation_sms(to_number) }
+    let(:to_number) { "07700900000" }
+    let(:params) { { reference_number: "ABC123" } }
+
+    it "renders the headers" do
+      expect(mail.to).to eq([to_number])
+    end
+
+    it "includes the reference" do
+      expect(mail.body.encoded).to include(params.dig(:reference_number))
+    end
+  end
 end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -80,8 +80,8 @@ module FillInTheFormSteps
   def and_has_given_their_contact_details
     expect(page.body).to have_content(I18n.t("coronavirus_form.questions.contact_details.title"))
     within find(".govuk-main-wrapper") do
-      fill_in "phone_number_calls", with: "01234567890"
-      fill_in "phone_number_texts", with: "01234567890"
+      fill_in "phone_number_calls", with: Rails.application.config.test_telephone_number
+      fill_in "phone_number_texts", with: Rails.application.config.test_telephone_number
       fill_in "email", with: Rails.application.config.courtesy_copy_email
       click_on I18n.t("coronavirus_form.submit_and_next")
     end


### PR DESCRIPTION
What
----

Sends a confirmation text message to registrants who have entered a UK mobile telephone number into the "phone number for text messages" field.

Content is currently awaiting departmental sign-off, so this PR cannot yet be merged.

Example of SMS:
![kAJUmrd8](https://user-images.githubusercontent.com/6329861/81176726-768fe280-8f9d-11ea-91c0-2783d83559bb.png)

How to review
-------------

- Review code changes.
- Set up and run application locally using a Notify API token.  Ensure text message is sent through Notify interface.

Links
-----

Trello card: https://trello.com/c/8L0b1iIg