### PR TITLE
New question logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,31 @@ to process the email queue.
 Sidekiq will start automatically when you run `foreman start`, but you can
 also run it alone with `bundle exec sidekiq`.
 
-#### Sending emails or SMSs locally
+### Sending emails or SMSs locally
 
-You'll need to pass a GOV.UK Notify API key as an environment variable
-`NOTIFY_API_KEY`, and change the delivery method in [development.rb][]:
+Change the delivery method in [development.rb][]:
 
 ```ruby
 config.action_mailer.delivery_method = :notify_email
 ```
 
-You'll also need to set a `GOVUK_NOTIFY_EMAIL_TEMPLATE_ID` and
-`GOVUK_NOTIFY_SMS_TEMPLATE_ID`, which might involve creating a
-template in Notify if your Notify service doesn't have one.
+You'll then need to pass a GOV.UK Notify API key as an environment variable
+`NOTIFY_API_KEY` as well the `GOVUK_NOTIFY_EMAIL_TEMPLATE_ID` and
+`GOVUK_NOTIFY_SMS_TEMPLATE_ID` template IDs.
+
+You can create an api key here: https://www.notifications.service.gov.uk/services/6ba785b8-71e0-4d0e-9f41-b7aa8876e5a9/api/keys
+
+Make sure to pick either "Team and whitelist" or "Testing". The api key can be revoked later.
+
+If you're testing SMS as well, make sure you have a mobile number associated with your Notify profile.
+
+#### Running the app
+
+```bash
+GOVUK_NOTIFY_EMAIL_TEMPLATE_ID=<email_template_id_from_notify> GOVUK_NOTIFY_SMS_TEMPLATE_ID=<sms_template_id_from_notify> NOTIFY_API_KEY=<your_api_key> foreman start
+```
+
+If your Notify service doesn't have a template you'll need to create a template in Notify.
 
 The template should have a Message of `((body))` only.
 

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -11,6 +11,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
   def submit
     submission_reference = reference_number
+    contact_gp = contact_gp?
 
     session[:reference_id] = submission_reference
 
@@ -35,7 +36,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
     reset_session
 
-    redirect_to confirmation_url(reference_number: submission_reference)
+    redirect_to confirmation_url(reference_number: submission_reference, contact_gp: contact_gp)
   end
 
 private
@@ -88,5 +89,9 @@ private
 
   def session_with_indifferent_access
     session.to_h.with_indifferent_access
+  end
+
+  def contact_gp?
+    session[:nhs_letter] != I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
   end
 end

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -11,7 +11,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
   def submit
     submission_reference = reference_number
-    contact_gp = contact_gp?
+    @contact_gp = contact_gp?
 
     session[:reference_id] = submission_reference
 
@@ -36,7 +36,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
     reset_session
 
-    redirect_to confirmation_url(reference_number: submission_reference, contact_gp: contact_gp)
+    redirect_to confirmation_url(reference_number: submission_reference, contact_gp: @contact_gp)
   end
 
 private
@@ -58,6 +58,7 @@ private
       first_name: session_with_indifferent_access.dig(:name, :first_name),
       last_name: session_with_indifferent_access.dig(:name, :last_name),
       reference_number: reference_number,
+      contact_gp: @contact_gp,
     )
     mailer.confirmation_email(user_email).deliver_later
   end

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -68,6 +68,7 @@ private
       first_name: session_with_indifferent_access.dig(:name, :first_name),
       last_name: session_with_indifferent_access.dig(:name, :last_name),
       reference_number: reference_number,
+      contact_gp: @contact_gp,
     )
     mailer.confirmation_sms(user_mobile_number).deliver_later
   end

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -12,12 +12,6 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
   def submit
     submission_reference = reference_number
 
-    # TODO: remove this once data export has been updated to allow new answers to medical conditions question
-    if session[:medical_conditions] == I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_medical.label") ||
-        session[:medical_conditions] == I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_gp.label")
-      session[:medical_conditions] = "Yes, I have one of the medical conditions on the list"
-    end
-
     session[:reference_id] = submission_reference
 
     validation_errors = validate_against_form_response_schema(session.to_h)

--- a/app/controllers/coronavirus_form/confirmation_controller.rb
+++ b/app/controllers/coronavirus_form/confirmation_controller.rb
@@ -2,4 +2,9 @@
 
 class CoronavirusForm::ConfirmationController < ApplicationController
   skip_before_action :check_first_question
+
+  def show
+    @contact_gp = params[:contact_gp]
+    super
+  end
 end

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -43,6 +43,8 @@ private
   end
 
   def previous_path
+    return nhs_letter_path unless session[:medical_conditions]
+
     medical_conditions_path
   end
 end

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -18,15 +18,15 @@ class CoronavirusForm::NhsLetterController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
+    elsif @form_responses[:nhs_letter] != I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
+      set_session_values
+      redirect_to medical_conditions_url
     elsif session[:check_answers_seen]
       set_session_values
       redirect_to check_your_answers_url
     elsif @form_responses[:nhs_letter] == I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
       set_session_values
       redirect_to name_url
-    else
-      set_session_values
-      redirect_to medical_conditions_url
     end
   end
 

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -21,6 +21,9 @@ class CoronavirusForm::NhsLetterController < ApplicationController
     elsif session[:check_answers_seen]
       session[:nhs_letter] = @form_responses[:nhs_letter]
       redirect_to check_your_answers_url
+    elsif @form_responses[:nhs_letter] == I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
+      session[:nhs_letter] = @form_responses[:nhs_letter]
+      redirect_to name_url
     else
       session[:nhs_letter] = @form_responses[:nhs_letter]
       redirect_to medical_conditions_url

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -19,18 +19,23 @@ class CoronavirusForm::NhsLetterController < ApplicationController
         format.html { render controller_path, status: :unprocessable_entity }
       end
     elsif session[:check_answers_seen]
-      session[:nhs_letter] = @form_responses[:nhs_letter]
+      set_session_values
       redirect_to check_your_answers_url
     elsif @form_responses[:nhs_letter] == I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
-      session[:nhs_letter] = @form_responses[:nhs_letter]
+      set_session_values
       redirect_to name_url
     else
-      session[:nhs_letter] = @form_responses[:nhs_letter]
+      set_session_values
       redirect_to medical_conditions_url
     end
   end
 
 private
+
+  def set_session_values
+    session[:nhs_letter] = @form_responses[:nhs_letter]
+    session[:medical_conditions] = nil if @form_responses[:nhs_letter] == I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
+  end
 
   def previous_path
     live_in_england_path

--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -17,7 +17,7 @@ module AnswersHelper
   end
 
   def skip_question?(question, answer)
-    question == "nhs_number" && answer.nil?
+    question.in?(%w[nhs_number medical_conditions]) && answer.nil?
   end
 
   def concat_answer(answer, question)

--- a/app/mailers/coronavirus_form_mailer.rb
+++ b/app/mailers/coronavirus_form_mailer.rb
@@ -5,6 +5,8 @@ class CoronavirusFormMailer < ApplicationMailer
     @first_name = params[:first_name]
     @last_name = params[:last_name]
     @reference_number = params[:reference_number]
+    @contact_gp = params[:contact_gp]
+
     mail(
       to: email_address,
       subject: I18n.t("emails.confirmation.subject"),

--- a/app/mailers/coronavirus_form_mailer.rb
+++ b/app/mailers/coronavirus_form_mailer.rb
@@ -18,6 +18,8 @@ class CoronavirusFormMailer < ApplicationMailer
     @first_name = params[:first_name]
     @last_name = params[:last_name]
     @reference_number = params[:reference_number]
+    @contact_gp = params[:contact_gp]
+
     mail(
       to: telephone_number,
       delivery_method: :notify_sms,

--- a/app/views/coronavirus_form/confirmation.html.erb
+++ b/app/views/coronavirus_form/confirmation.html.erb
@@ -3,4 +3,4 @@
   title: t("coronavirus_form.confirmation.title")
 } %>
 
-<%= sanitize(t("coronavirus_form.confirmation.description")) %>
+<%= sanitize(t('coronavirus_form.confirmation.no_further_action.description')) %>

--- a/app/views/coronavirus_form/confirmation.html.erb
+++ b/app/views/coronavirus_form/confirmation.html.erb
@@ -3,4 +3,8 @@
   title: t("coronavirus_form.confirmation.title")
 } %>
 
-<%= sanitize(t('coronavirus_form.confirmation.no_further_action.description')) %>
+<% if @contact_gp == "true" %>
+  <%= sanitize(t('coronavirus_form.confirmation.contact_gp.description')) %>
+<% else %>
+  <%= sanitize(t('coronavirus_form.confirmation.no_further_action.description')) %>
+<% end %>

--- a/app/views/coronavirus_form_mailer/confirmation_email.text.erb
+++ b/app/views/coronavirus_form_mailer/confirmation_email.text.erb
@@ -1,3 +1,3 @@
 Dear <%= @first_name %> <%= @last_name %>,
 
-<%= t("emails.confirmation.body_text", reference_number: @reference_number) %>
+<%= t("emails.confirmation.no_further_action.body_text", reference_number: @reference_number) %>

--- a/app/views/coronavirus_form_mailer/confirmation_email.text.erb
+++ b/app/views/coronavirus_form_mailer/confirmation_email.text.erb
@@ -1,3 +1,7 @@
 Dear <%= @first_name %> <%= @last_name %>,
 
-<%= t("emails.confirmation.no_further_action.body_text", reference_number: @reference_number) %>
+<% if @contact_gp %>
+  <%= t("emails.confirmation.contact_gp.body_text", reference_number: @reference_number) %>
+<% else %>
+  <%= t("emails.confirmation.no_further_action.body_text", reference_number: @reference_number) %>
+<% end %>

--- a/app/views/coronavirus_form_mailer/confirmation_sms.text.erb
+++ b/app/views/coronavirus_form_mailer/confirmation_sms.text.erb
@@ -1,1 +1,1 @@
-<%= t("sms.confirmation.body_text", first_name: @first_name, last_name: @last_name, reference_number: @reference_number) %>
+<%= t("sms.confirmation.no_further_action.body_text", first_name: @first_name, last_name: @last_name, reference_number: @reference_number) %>

--- a/app/views/coronavirus_form_mailer/confirmation_sms.text.erb
+++ b/app/views/coronavirus_form_mailer/confirmation_sms.text.erb
@@ -1,1 +1,5 @@
-<%= t("sms.confirmation.no_further_action.body_text", first_name: @first_name, last_name: @last_name, reference_number: @reference_number) %>
+<% if @contact_gp %>
+  <%= t("sms.confirmation.contact_gp.body_text", first_name: @first_name, last_name: @last_name, reference_number: @reference_number) %>
+<% else %>
+  <%= t("sms.confirmation.no_further_action.body_text", first_name: @first_name, last_name: @last_name, reference_number: @reference_number) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,44 +209,39 @@ en:
   emails:
     confirmation:
       subject: "Coronavirus support service: your registration"
-      body_text: |
-        Your registration number is %{reference_number}.
+      no_further_action:
+        body_text: |
+          Your registration number is %{reference_number}.
 
-        You do not need to do anything else if you’ve had a letter from the NHS or from your doctor confirming that they’ve identified you as being clinically extremely vulnerable.
+          # What happens next
 
-        ## If you haven’t had a letter from the NHS or from your doctor
+          We’ll check your details to make sure you’re eligible for support. You’ll only get support if you asked for it.
 
-        Contact your GP or hospital clinician as soon as possible so they can confirm to us you’re classed as clinically extremely vulnerable. You may not get the support you need if you do not contact them.
+          If we need to confirm any details, you’ll get a call from the National Shielding Service. The number that will show on your phone is 0333 3050466.
 
-        ## What happens next
+          # Getting support
 
-        We’ll check your details to make sure you’re eligible for support. You’ll only get support if you asked for it.
+          If you’re eligible and you said that you do not have a way of getting basic supplies at the moment we will start sending you a weekly box of basic supplies.
 
-        If we need to confirm any details, you’ll get a call from the National Shielding Service. The number that will show on your phone is 0333 3050466.
+          If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.
 
-        ## Getting support
+          This can take up to a week. Contact your local authority if you need supplies urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help
 
-        If you’re eligible and you said that you do not have a way of getting basic supplies at the moment we will start sending you a weekly box of basic supplies.
+          # If your support needs change
 
-        If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.
+          You can tell the delivery driver if you want to stop getting the weekly box of supplies.
 
-        This can take up to a week - or longer if you haven’t had the letter from your NHS or from your doctor. Contact your local authority if you need supplies urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help
+          If your support needs change, go through the questions in the service again: https://www.gov.uk/coronavirus-extremely-vulnerable.
 
-        ## If your support needs change
+          There’s guidance on things you should do if you’re extremely vulnerable to coronavirus: https://www.gov.uk/coronavirus-extremely-vulnerable-guidance.
 
-        You can tell the delivery driver if you want to stop getting the weekly box of supplies.
+          Thanks,
 
-        If your support needs change, go through the questions in the service again: https://www.gov.uk/coronavirus-extremely-vulnerable.
+          Coronavirus support team
 
-        There’s guidance on things you should do if you’re extremely vulnerable to coronavirus: https://www.gov.uk/coronavirus-extremely-vulnerable-guidance.
+          -----
 
-        Thanks,
-
-        Coronavirus support team
-
-        -----
-
-        Do not reply to this email - it’s an automatic message from an unmonitored account.
+          Do not reply to this email - it’s an automatic message from an unmonitored account.
   coronavirus_form:
     submit_and_next: "Continue"
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,32 +267,33 @@ en:
       telephone_number_format: "Enter a telephone number, like 020 7946 0000, 07700900000 or +44 0808 157 0192"
     confirmation:
       title: Registration complete
-      description: |
-        <h2 class="govuk-heading-m">What happens next</h2>
-        <p class="govuk-body">We'll check that you're eligible for support first.</p>
-        <p class="govuk-body">Then if you said that you do not have a way of getting basic supplies at the moment, we will:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>start sending you a a weekly box of basic supplies</li>
-          <li>tell participating supermarkets to give you priority for deliveries</li>
-        </ul>
-        <p class="govuk-body">This may take up to a week.</p>
-        <p class="govuk-body"><a class="govuk-link" href="https://www.theyhelpyou.co.uk/">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
-        <h2 class="govuk-heading-m">Priority supermarket deliveries</h2>
-        <p class="govuk-body">If you do not already have an account with a supermarket delivery service, set one up now. If you're concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li><a class="govuk-link" href="https://www.aldi.co.uk/food-parcels">Aldi</a></li>
-          <li><a class="govuk-link" href="https://groceries.asda.com/">Asda</a></li>
-          <li><a class="govuk-link" href="https://www.coop.co.uk/in-store-services/home-delivery">Co-op</a></li>
-          <li><a class="govuk-link" href="https://www.marksandspencer.com/">M&S</a></li>
-          <li><a class="govuk-link" href="https://groceries.morrisons.com">Morrisons</a></li>
-          <li><a class="govuk-link" href="https://www.ocado.com/">Ocado</a></li>
-          <li><a class="govuk-link" href="https://www.sainsburys.co.uk/">Sainsbury's</a></li>
-          <li><a class="govuk-link" href="https://www.tesco.com/">Tesco</a></li>
-        </ul>
-        <h2 class="govuk-heading-m">If your support needs change</h2>
-        <p class="govuk-body">You should <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>
-        <p class="govuk-body">There’s guidance on <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">things you should do if you’re extremely vulnerable to coronavirus</a>.
-        <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
+      no_further_action:
+        description: |
+          <h2 class="govuk-heading-m">What happens next</h2>
+          <p class="govuk-body">We’ll check that you’re eligible for support first.</p>
+          <p class="govuk-body">Then if you said that you do not have a way of getting basic supplies at the moment, we will:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>start sending you a a weekly box of basic supplies</li>
+            <li>tell participating supermarkets to give you priority for deliveries</li>
+          </ul>
+          <p class="govuk-body">This may take up to a week.</p>
+          <p class="govuk-body"><a class="govuk-link" href="https://www.theyhelpyou.co.uk/">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
+          <h2 class="govuk-heading-m">Priority supermarket deliveries</h2>
+          <p class="govuk-body">If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><a class="govuk-link" href="https://www.aldi.co.uk/food-parcels">Aldi</a></li>
+            <li><a class="govuk-link" href="https://groceries.asda.com/">Asda</a></li>
+            <li><a class="govuk-link" href="https://www.coop.co.uk/in-store-services/home-delivery">Co-op</a></li>
+            <li><a class="govuk-link" href="https://www.marksandspencer.com/">M&S</a></li>
+            <li><a class="govuk-link" href="https://groceries.morrisons.com">Morrisons</a></li>
+            <li><a class="govuk-link" href="https://www.ocado.com/">Ocado</a></li>
+            <li><a class="govuk-link" href="https://www.sainsburys.co.uk/">Sainsbury’s</a></li>
+            <li><a class="govuk-link" href="https://www.tesco.com/">Tesco</a></li>
+          </ul>
+          <h2 class="govuk-heading-m">If your support needs change</h2>
+          <p class="govuk-body">You should <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>
+          <p class="govuk-body">There’s guidance on <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">things you should do if you’re extremely vulnerable to coronavirus</a>.
+          <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
     questions:
       # These should be in the order that they’re asked
       live_in_england:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,6 +294,27 @@ en:
           <p class="govuk-body">You should <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>
           <p class="govuk-body">There’s guidance on <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">things you should do if you’re extremely vulnerable to coronavirus</a>.
           <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
+      contact_gp:
+        description: |
+          <h2 class="govuk-heading-m">Contact your GP</h2>
+
+          <p class="govuk-body">Contact your GP or hospital clinician as soon as possible so they can confirm to us you’re classed as clinically extremely vulnerable. You may not get the support you need if you do not contact them.</p>
+
+          <h2 class="govuk-heading-m">What happens next</h2>
+
+          <p class="govuk-body">When we’ve had the confirmation from your GP we’ll check your details to make sure you’re eligible for support. You’ll only get support if you asked for it.</p>
+          <p class="govuk-body">If we need to confirm any details, you’ll get a call from the National Shielding Service. The number that will show on your phone is 0333 3050466.</p>
+
+          <h2 class="govuk-heading-m">Getting support</h2>
+          <p class="govuk-body">If you’re eligible and you said that you do not have a way of getting basic supplies at the moment we will start sending you a weekly box of basic supplies.</p>
+          <p class="govuk-body">We’ll also share your details with participating supermarkets to help them prioritise you for their delivery services.</p>
+          <p class="govuk-body">If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.</p>
+          <p class="govuk-body">This can take up to a week from when we get the confirmation from your GP or hospital clinician. <a class="govuk-link" href="https://www.gov.uk/coronavirus-local-help">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
+          <h2 class="govuk-heading-m">If your support needs change</h2>
+          <p class="govuk-body">You can tell the delivery driver if you want to stop getting the weekly box of supplies.</p>
+          <p class="govuk-body">If your support needs change, <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>
+          <p class="govuk-body">There’s guidance on <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">things you should do if you’re extremely vulnerable to coronavirus</a>.
+          <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
     questions:
       # These should be in the order that they’re asked
       live_in_england:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,20 +268,29 @@ en:
     confirmation:
       title: Registration complete
       description: |
-        <p class="govuk-body">You do not need to do anything else if you’ve had a letter from the NHS or from your doctor confirming that they’ve identified you as being clinically extremely vulnerable.</p>
-        <h2 class="govuk-heading-m">If you haven’t had a letter from the NHS or from your doctor</h2>
-        <p class="govuk-body">Contact your GP or hospital clinician as soon as possible so they can confirm to us you’re classed as clinically extremely vulnerable. You may not get the support you need if you do not contact them.</p>
         <h2 class="govuk-heading-m">What happens next</h2>
-        <p class="govuk-body">We’ll check your details to make sure you’re eligible for support. You’ll only get support if you asked for it.</p>
-        <p class="govuk-body">If we need to confirm any details, you’ll get a call from the National Shielding Service. The number that will show on your phone is 0333 3050466.</p>
-        <h2 class="govuk-heading-m">Getting support</h2>
-        <p class="govuk-body">If you’re eligible and you said that you do not have a way of getting basic supplies at the moment we will start sending you a weekly box of basic supplies.</p>
-        <p class="govuk-body">We’ll also share your details with participating supermarkets to help them prioritise you for their delivery services.</p>
-        <p class="govuk-body">If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.</p>
-        <p class="govuk-body">This can take up to a week - or longer if you haven’t had the letter from your NHS or from your doctor. <a class="govuk-link" href="https://www.gov.uk/coronavirus-local-help">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
+        <p class="govuk-body">We'll check that you're eligible for support first.</p>
+        <p class="govuk-body">Then if you said that you do not have a way of getting basic supplies at the moment, we will:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>start sending you a a weekly box of basic supplies</li>
+          <li>tell participating supermarkets to give you priority for deliveries</li>
+        </ul>
+        <p class="govuk-body">This may take up to a week.</p>
+        <p class="govuk-body"><a class="govuk-link" href="https://www.theyhelpyou.co.uk/">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
+        <h2 class="govuk-heading-m">Priority supermarket deliveries</h2>
+        <p class="govuk-body">If you do not already have an account with a supermarket delivery service, set one up now. If you're concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a class="govuk-link" href="https://www.aldi.co.uk/food-parcels">Aldi</a></li>
+          <li><a class="govuk-link" href="https://groceries.asda.com/">Asda</a></li>
+          <li><a class="govuk-link" href="https://www.coop.co.uk/in-store-services/home-delivery">Co-op</a></li>
+          <li><a class="govuk-link" href="https://www.marksandspencer.com/">M&S</a></li>
+          <li><a class="govuk-link" href="https://groceries.morrisons.com">Morrisons</a></li>
+          <li><a class="govuk-link" href="https://www.ocado.com/">Ocado</a></li>
+          <li><a class="govuk-link" href="https://www.sainsburys.co.uk/">Sainsbury's</a></li>
+          <li><a class="govuk-link" href="https://www.tesco.com/">Tesco</a></li>
+        </ul>
         <h2 class="govuk-heading-m">If your support needs change</h2>
-        <p class="govuk-body">You can tell the delivery driver if you want to stop getting the weekly box of supplies.</p>
-        <p class="govuk-body">If your support needs change, <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>
+        <p class="govuk-body">You should <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>
         <p class="govuk-body">There’s guidance on <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">things you should do if you’re extremely vulnerable to coronavirus</a>.
         <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
     questions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,9 +306,8 @@ en:
             label: "Not sure"
         custom_select_error: Select if you received the letter from the NHS
       medical_conditions:
-        title: Do you have one of the listed medical conditions, or have you been told to ‘shield’ by your GP or hospital clinician?
+        title: Do you have one of the listed medical conditions?
         description: |
-          <p class="govuk-body">‘Shielding’ means not leaving your home and minimising contact with other members of your household.</p>
           <p class="govuk-body">You have one of the listed medical conditions if you:</p>
           <ul class="govuk-list govuk-list--bullet app-list--spaced">
             <li>have had a solid organ transplant</li>
@@ -324,12 +323,10 @@ en:
             <li>are pregnant, and have a significant congenital or acquired heart disease</li>
           </ul>
         options:
-          option_yes_medical:
+          option_yes:
             label: "Yes, I have one of the listed medical conditions"
-          option_yes_gp:
-            label: "Yes, my GP or hospital clinician has told me to ‘shield’"
           option_no:
-            label: "No, I do not have one of the listed medical conditions - and I have not been told to ‘shield’"
+            label: "No, I do not have one of the listed medical conditions"
         custom_select_error: Select yes if you have one of the medical conditions on the list
       name:
         title: What is your name?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -295,13 +295,13 @@ en:
             label: "No"
         custom_select_error: Select yes if you live in England
       nhs_letter:
-        title: Have you recently had a letter from the NHS about your situation as someone who’s extremely vulnerable to coronavirus?
-        hint: The title of the letter is ‘Important advice to keep you safe from coronavirus’.
+        title: Have you had a letter from the NHS or been told by your doctor to ’shield’ because you’re clinically extremely vulnerable to coronavirus?
+        hint: ’Shielding’ means not leaving your home and avoiding contact with other members of your household as much as possible.
         options:
           option_yes:
-            label: "Yes"
+            label: "Yes, I’ve been told to shield"
           option_no:
-            label: "No"
+            label: "No, I haven’t been told to shield"
           not_sure:
             label: "Not sure"
         custom_select_error: Select if you received the letter from the NHS

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,6 +205,19 @@ en:
           If you want priority supermarket deliveries and do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
 
           If your support needs change, go to https://www.gov.uk/coronavirus-extremely-vulnerable and answer the questions again.
+      contact_gp:
+        body_text: |
+          Hello %{first_name} %{last_name} - we’ve received your registration as someone who’s extremely vulnerable to coronavirus.
+
+          Contact your doctor as soon as possible so they can confirm to us you’re classed as clinically extremely vulnerable. You may not get the support you need if you do not contact them.
+
+          After that we’ll check that you’re eligible, and you’ll start getting support if you asked for it.
+
+          This can take up to a week from when we get the confirmation from your doctor. Contact your local authority if you need urgent support and can’t rely on friends or neighbours: https://www.gov.uk/coronavirus-local-help
+
+          If you want priority supermarket deliveries and do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
+
+          If your needs change, go to https://www.gov.uk/coronavirus-extremely-vulnerable and answer the questions again.
   emails:
     confirmation:
       subject: "Coronavirus support service: your registration"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,18 +194,17 @@ en:
       <p class="govuk-body">You may be seeing this page because you’ve turned off cookies in your browser. You’ll need to <a class="govuk-link" href="https://ico.org.uk/your-data-matters/online/cookies/" rel="external" target="_blank">turn cookies on</a> before you can use this service.</p>
   sms:
     confirmation:
-      body_text: |
-        We’ve received your registration as someone who’s clinically extremely vulnerable to coronavirus.
+      no_further_action:
+        body_text: |
+          Hello %{first_name} %{last_name} - we’ve received your registration as someone who’s extremely vulnerable to coronavirus.
 
-        You do not need to do anything else if you’ve had a letter from the NHS or your doctor confirming that you’re clinically extremely vulnerable. If you haven’t, contact your GP as soon as possible. Otherwise you may not get support.
+          We’ll check that you’re eligible, then you’ll start getting support if you asked for it.
 
-        We’ll check you’re eligible, then you’ll start getting support if you asked for it.
+          This can take up to a week. Contact your local authority if you need urgent support and cannot rely on friends or neighbours: https://www.gov.uk/coronavirus-local-help
 
-        This can take up to a week, or longer if you haven't had the letter from your NHS or from your doctor. Contact your local authority if you need urgent support and can’t rely on friends or neighbours.
+          If you want priority supermarket deliveries and do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
 
-        If you want priority supermarket deliveries and do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
-
-        If your needs change, go to https://www.gov.uk/coronavirus-extremely-vulnerable and answer the questions again.
+          If your support needs change, go to https://www.gov.uk/coronavirus-extremely-vulnerable and answer the questions again.
   emails:
     confirmation:
       subject: "Coronavirus support service: your registration"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,28 +300,17 @@ en:
       no_further_action:
         description: |
           <h2 class="govuk-heading-m">What happens next</h2>
-          <p class="govuk-body">We’ll check that you’re eligible for support first.</p>
-          <p class="govuk-body">Then if you said that you do not have a way of getting basic supplies at the moment, we will:</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>start sending you a a weekly box of basic supplies</li>
-            <li>tell participating supermarkets to give you priority for deliveries</li>
-          </ul>
-          <p class="govuk-body">This may take up to a week.</p>
-          <p class="govuk-body"><a class="govuk-link" href="https://www.theyhelpyou.co.uk/">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
-          <h2 class="govuk-heading-m">Priority supermarket deliveries</h2>
+
+          <p class="govuk-body">We’ll check your details to make sure you’re eligible for support. You’ll only get support if you asked for it.</p>
+          <p class="govuk-body">If we need to confirm any details, you’ll get a call from the National Shielding Service. The number that will show on your phone is 0333 3050466.</p>
+          <h2 class="govuk-heading-m">Getting support</h2>
+          <p class="govuk-body">If you’re eligible and you said that you do not have a way of getting basic supplies at the moment we will start sending you a weekly box of basic supplies.</p>
+          <p class="govuk-body">We’ll also share your details with participating supermarkets to help them prioritise you for their delivery services.</p>
           <p class="govuk-body">If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li><a class="govuk-link" href="https://www.aldi.co.uk/food-parcels">Aldi</a></li>
-            <li><a class="govuk-link" href="https://groceries.asda.com/">Asda</a></li>
-            <li><a class="govuk-link" href="https://www.coop.co.uk/in-store-services/home-delivery">Co-op</a></li>
-            <li><a class="govuk-link" href="https://www.marksandspencer.com/">M&S</a></li>
-            <li><a class="govuk-link" href="https://groceries.morrisons.com">Morrisons</a></li>
-            <li><a class="govuk-link" href="https://www.ocado.com/">Ocado</a></li>
-            <li><a class="govuk-link" href="https://www.sainsburys.co.uk/">Sainsbury’s</a></li>
-            <li><a class="govuk-link" href="https://www.tesco.com/">Tesco</a></li>
-          </ul>
+          <p class="govuk-body">This can take up to a week. <a class="govuk-link" href="https://www.gov.uk/coronavirus-local-help">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
           <h2 class="govuk-heading-m">If your support needs change</h2>
-          <p class="govuk-body">You should <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>
+          <p class="govuk-body">You can tell the delivery driver if you want to stop getting the weekly box of supplies.</p>
+          <p class="govuk-body">If your support needs change, <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>
           <p class="govuk-body">There’s guidance on <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">things you should do if you’re extremely vulnerable to coronavirus</a>.
           <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
       contact_gp:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,6 +242,41 @@ en:
           -----
 
           Do not reply to this email - it’s an automatic message from an unmonitored account.
+      contact_gp:
+        body_text: |
+          # Contact your GP
+
+          Contact your GP or hospital clinician as soon as possible so they can confirm to us you’re classed as clinically extremely vulnerable. You may not get the support you need if you do not contact them.
+
+          # What happens next
+
+          We’ll check your details to make sure you’re eligible for support. You’ll only get support if you asked for it.
+
+          If we need to confirm any details, you’ll get a call from the National Shielding Service. The number that will show on your phone is 0333 3050466.
+
+          # Getting support
+
+          If you’re eligible and you said that you do not have a way of getting basic supplies at the moment we will start sending you a weekly box of basic supplies.
+
+          If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.
+
+          This can take up to a week from when we get the confirmation from your GP or hospital clinician. Contact your local authority if you need supplies urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help
+
+          # If your support needs change
+
+          You can tell the delivery driver if you want to stop getting the weekly box of supplies.
+
+          If your support needs change, go through the questions in the service again: https://www.gov.uk/coronavirus-extremely-vulnerable.
+
+          There’s guidance on things you should do if you’re extremely vulnerable to coronavirus: https://www.gov.uk/coronavirus-extremely-vulnerable-guidance.
+
+          Thanks,
+
+          Coronavirus support team
+
+          -----
+
+          Do not reply to this email - it’s an automatic message from an unmonitored account.
   coronavirus_form:
     submit_and_next: "Continue"
     errors:

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -22,8 +22,8 @@
     "nhs_letter": {
       "type": "string",
       "enum": [
-        "Yes",
-        "No",
+        "Yes, I’ve been told to shield",
+        "No, I haven’t been told to shield",
         "Not sure"
       ]
     },

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -4,7 +4,6 @@
   "required": [
     "live_in_england",
     "nhs_letter",
-    "medical_conditions",
     "name",
     "date_of_birth",
     "support_address",

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -29,10 +29,8 @@
     "medical_conditions": {
       "type": "string",
       "enum": [
-        "Yes, I have one of the medical conditions on the list",
         "Yes, I have one of the listed medical conditions",
-        "Yes, my GP or hospital clinician has told me to ‘shield’",
-        "No, I do not have one of the listed medical conditions - and I have not been told to ‘shield’"
+        "No, I do not have one of the listed medical conditions"
       ]
     },
     "name": {

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -88,7 +88,11 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
       expect {
         post :submit
       }.to have_enqueued_mail(CoronavirusFormMailer, :confirmation_sms)
-        .with(a_hash_including(reference_number: "abc"), "07790900000").on_queue("mailers")
+        .with(a_hash_including(
+                reference_number: "abc",
+                contact_gp: true,
+              ),
+              "07790900000").on_queue("mailers")
     end
 
     it "does not send a text message when no phone number for texting is provided" do

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -59,7 +59,13 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
       expect {
         post :submit
       }.to have_enqueued_mail(CoronavirusFormMailer, :confirmation_email)
-        .with(a_hash_including(first_name: "John", last_name: "Smith", reference_number: "abc"), "name@example.org").on_queue("mailers")
+        .with(a_hash_including(
+                first_name: "John",
+                last_name: "Smith",
+                reference_number: "abc",
+                contact_gp: true,
+              ),
+              "name@example.org").on_queue("mailers")
     end
 
     it "does not send an email when no email address provided" do

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -101,13 +101,36 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
       expect(session.to_hash).to eq({})
     end
 
-    it "redirects to thank you if sucessfully creates record" do
+    it "sets contact_gp to false and redirects to confirmation if user received an nhs letter" do
+      session[:nhs_letter] = I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
       post :submit
 
       expect(response).to redirect_to({
         controller: "confirmation",
         action: "show",
-        params: { reference_number: "abc" },
+        params: {
+          reference_number: "abc",
+          contact_gp: false,
+        },
+      })
+    end
+
+    it "sets contact_gp to true and redirects to confirmation if user did not receive an nhs letter" do
+      permitted_values = [
+        I18n.t("coronavirus_form.questions.basic_care_needs.options.option_no.label"),
+        I18n.t("coronavirus_form.questions.basic_care_needs.options.not_sure.label"),
+      ]
+
+      session[:nhs_letter] = permitted_values.sample
+      post :submit
+
+      expect(response).to redirect_to({
+        controller: "confirmation",
+        action: "show",
+        params: {
+          reference_number: "abc",
+          contact_gp: true,
+        },
       })
     end
 

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -111,22 +111,6 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
       })
     end
 
-    it "replaces medical conditions listed response with legacy answer" do
-      session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_medical.label")
-
-      post :submit
-
-      expect(FormResponse.last.attributes.dig(:FormResponse, :medical_conditions)).to eq("Yes, I have one of the medical conditions on the list")
-    end
-
-    it "replaces medical conditions GP response with legacy answer" do
-      session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_gp.label")
-
-      post :submit
-
-      expect(FormResponse.last.attributes.dig(:FormResponse, :medical_conditions)).to eq("Yes, I have one of the medical conditions on the list")
-    end
-
     it "doesn't create a FormResponse if the user is the smoke tester identidied by email" do
       session[:contact_details] = { email: Rails.application.config.courtesy_copy_email }
       session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_gp.label")

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -41,7 +41,20 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
       expect(response).to render_template(current_template)
     end
 
-    it "redirects to next step for a permitted response" do
+    it "redirects to what is your name question if user answers yes" do
+      selected = I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
+      post :submit, params: { nhs_letter: selected }
+      expect(response).to redirect_to(name_path)
+    end
+
+    it "redirects to medical conditions question if user answers no" do
+      selected = I18n.t("coronavirus_form.questions.nhs_letter.options.option_no.label")
+      post :submit, params: { nhs_letter: selected }
+      expect(response).to redirect_to(medical_conditions_path)
+    end
+
+    it "redirects to medical conditions question if user answers not sure" do
+      selected = I18n.t("coronavirus_form.questions.nhs_letter.options.not_sure.label")
       post :submit, params: { nhs_letter: selected }
       expect(response).to redirect_to(medical_conditions_path)
     end

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -65,5 +65,16 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
 
       expect(response).to redirect_to(check_your_answers_path)
     end
+
+    it "clears the medical_conditions if the user changes their answer to Yes" do
+      session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes.label")
+
+      post :submit,
+           params: {
+             nhs_letter: I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label"),
+           }
+
+      expect(session[:medical_conditions]).to be_nil
+    end
   end
 end

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature "fill in the vulnerable people form" do
       given_an_extremely_vulnerable_person_during_the_covid_19_pandemic
       that_lives_in_england
       and_has_recently_received_an_nhs_letter
-      who_has_a_listed_medical_condition
       and_has_given_their_name
       and_has_given_their_date_of_birth
       and_has_given_their_address
@@ -51,10 +50,19 @@ RSpec.feature "fill in the vulnerable people form" do
   scenario "visitor not eligible as they do not have a listed medical condition" do
     given_an_extremely_vulnerable_person_during_the_covid_19_pandemic
     that_lives_in_england
-    and_has_recently_received_an_nhs_letter
+    and_has_not_recently_received_an_nhs_letter
     who_does_not_have_a_listed_medical_condition
 
     expect(page.body).to have_content(I18n.t("not_eligible_medical.title"))
+  end
+
+  scenario "visitor has not received a letter, but has a medical condition" do
+    given_an_extremely_vulnerable_person_during_the_covid_19_pandemic
+    that_lives_in_england
+    and_has_not_recently_received_an_nhs_letter
+    who_has_a_listed_medical_condition
+
+    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.name.title"))
   end
 
   scenario "ensure we can perform a healthcheck" do

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe AnswersHelper, type: :helper do
         )
       end
     end
+
+    context "medical_conditions" do
+      it "includes the medical_conditions question if it has a value" do
+        session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes.label")
+        expect(helper.answer_items.pluck(:field)).to include(
+          I18n.t("coronavirus_form.questions.medical_conditions.title"),
+        )
+      end
+
+      it "skips the medical_conditions question if the value is nil" do
+        expect(helper.answer_items.pluck(:field)).to_not include(
+          I18n.t("coronavirus_form.questions.medical_conditions.title"),
+        )
+      end
+    end
   end
 
   describe "#concat_answer" do

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe SchemaHelper, type: :helper do
     end
 
     describe "medical_conditions" do
-      it "returns a list of errors when medical_conditions is missing" do
+      it "allows medical_conditions to be blank" do
         data = valid_data.except(:medical_conditions)
-        expect(validate_against_form_response_schema(data).first).to include("medical_conditions")
+        expect(validate_against_form_response_schema(data)).to be_empty
       end
 
       it "returns a list of errors when medical_conditions has an unexpected value" do

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe I18n, type: :feature do
   context "SMS content" do
     it "all body text is less than or equal to 918 characters" do
-      I18n.t("sms").each do |_, sms_type|
+      I18n.t("sms.confirmation").each do |_, sms_type|
         expect(sms_type[:body_text].chomp.length).to be <= 918
       end
     end

--- a/spec/mailers/coronavirus_form_mailer_spec.rb
+++ b/spec/mailers/coronavirus_form_mailer_spec.rb
@@ -44,7 +44,14 @@ RSpec.describe CoronavirusFormMailer, type: :mailer do
   describe "#confirmation_sms" do
     let(:mail) { CoronavirusFormMailer.with(params).confirmation_sms(to_number) }
     let(:to_number) { "07700900000" }
-    let(:params) { { first_name: "John", last_name: "Smith", reference_number: "ABC123" } }
+    let(:params) do
+      {
+        first_name: "John",
+        last_name: "Smith",
+        reference_number: "ABC123",
+        contact_gp: false,
+      }
+    end
 
     it "renders the headers" do
       expect(mail.to).to eq([to_number])
@@ -52,6 +59,14 @@ RSpec.describe CoronavirusFormMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded.squish).to include(I18n.t("sms.confirmation.no_further_action.body_text", first_name: "John", last_name: "Smith").squish)
+    end
+
+    it "renders alternate body text" do
+      params.merge!(contact_gp: true)
+
+      mail = CoronavirusFormMailer.with(params).confirmation_sms(to_number)
+
+      expect(mail.body.encoded.squish).to include(I18n.t("sms.confirmation.contact_gp.body_text", first_name: "John", last_name: "Smith").squish)
     end
   end
 end

--- a/spec/mailers/coronavirus_form_mailer_spec.rb
+++ b/spec/mailers/coronavirus_form_mailer_spec.rb
@@ -2,7 +2,15 @@ RSpec.describe CoronavirusFormMailer, type: :mailer do
   describe "#confirmation_email" do
     let(:mail) { CoronavirusFormMailer.with(params).confirmation_email(to_address) }
     let(:to_address) { "user@example.org" }
-    let(:params) { { first_name: "John", last_name: "Smith", reference_number: "ABC123" } }
+    let(:reference_number) { "ABC123" }
+    let(:params) do
+      {
+        first_name: "John",
+        last_name: "Smith",
+        reference_number: reference_number,
+        contact_gp: false,
+      }
+    end
 
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("emails.confirmation.subject"))
@@ -12,6 +20,20 @@ RSpec.describe CoronavirusFormMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to include("Dear #{params.dig(:first_name)} #{params.dig(:last_name)}")
+      expect(mail.body.encoded.squish).to include(I18n.t("emails.confirmation.no_further_action.body_text", reference_number: reference_number).squish)
+    end
+
+    it "renders alternate body text" do
+      params = {
+        first_name: "John",
+        last_name: "Smith",
+        reference_number: reference_number,
+        contact_gp: true,
+      }
+
+      mail = CoronavirusFormMailer.with(params).confirmation_email(to_address)
+
+      expect(mail.body.encoded.squish).to include(I18n.t("emails.confirmation.contact_gp.body_text", reference_number: reference_number).squish)
     end
 
     it "includes the reference" do

--- a/spec/mailers/coronavirus_form_mailer_spec.rb
+++ b/spec/mailers/coronavirus_form_mailer_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe CoronavirusFormMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to include("We’ve received your registration")
+      expect(mail.body.encoded.squish).to include(I18n.t("sms.confirmation.no_further_action.body_text", first_name: "John", last_name: "Smith").squish)
     end
   end
 end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -29,6 +29,14 @@ module FillInTheFormSteps
     end
   end
 
+  def and_has_not_recently_received_an_nhs_letter
+    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.nhs_letter.title"))
+    within find(".govuk-main-wrapper") do
+      choose I18n.t("coronavirus_form.questions.nhs_letter.options.option_no.label")
+      click_on I18n.t("coronavirus_form.submit_and_next")
+    end
+  end
+
   def who_has_a_listed_medical_condition
     expect(page.body).to have_content(I18n.t("coronavirus_form.questions.medical_conditions.title"))
     within find(".govuk-main-wrapper") do

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -40,7 +40,7 @@ module FillInTheFormSteps
   def who_has_a_listed_medical_condition
     expect(page.body).to have_content(I18n.t("coronavirus_form.questions.medical_conditions.title"))
     within find(".govuk-main-wrapper") do
-      choose I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_medical.label")
+      choose I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
     end
   end


### PR DESCRIPTION
Trello: 
- https://trello.com/c/0flnhchV
- https://trello.com/c/81u4ftj7

Review app 👉 https://coronavirus-new-questio-ustwsp.herokuapp.com/live-in-england

## What's changed?

Stephen G has created a new question logic that will reduce the number of steps for users and show different confirmation messages for different outcomes, meaning content can be more relevant to a user's circumstances.

Spike this approach (the `27 April` tab on the [questions protocol](https://docs.google.com/spreadsheets/d/1o0C0NabtFykGLpCXuDD_rRkKG9tAI4AVzQCMPeKx3ko/edit#gid=19251621)) to get an understanding of complexity, impact on the downstream data store and our analytics.

## Why?

 Adding routing to allow users to skip the medical conditions question if we don’t them to answer it simplifies the form for the majority of users. 

The idea behind having two different versions of the confirmation page is that the user only sees the version that says “contact your GP" if they haven't already had contact from their GP. The NHS wants to stop GPs being contacted unnecessarily.

## Expected changes
- Content changes to the NHS Letter page
- Medical conditions question is skipped if the user answers "Yes..." to NHS letter page
- Two variants of confirmation page:
  -- Contact GP (user selected "No...." or "Not sure" to NHS letter question)
  -- No further action (user selected "Yes..." to NHS letter question)
- Two variants of confirmation email:
  -- Contact GP (user selected "No...." or "Not sure" to NHS letter question)
  -- No further action (user selected "Yes..." to NHS letter question)
- Two variants of confirmation sms:
  -- Contact GP (user selected "No...." or "Not sure" to NHS letter question)
  -- No further action (user selected "Yes..." to NHS letter question)


### NHS letter page
<img width="1552" alt="Screenshot 2020-05-05 at 16 53 12" src="https://user-images.githubusercontent.com/5793815/81088254-a2a25980-8ef2-11ea-85e2-a333ca06f95b.png">

### Check answers page
#### Without medical conditions question
<img width="1552" alt="Screenshot 2020-05-05 at 16 52 39" src="https://user-images.githubusercontent.com/5793815/81088243-9fa76900-8ef2-11ea-992f-df093b32aa10.png">

#### With medical conditions question
<img width="1552" alt="Screenshot 2020-05-05 at 16 53 05" src="https://user-images.githubusercontent.com/5793815/81088256-a33af000-8ef2-11ea-8f57-f7fe574e073e.png">

### Confirmation page
#### Contact GP
![confirmation_page_contact_gp](https://user-images.githubusercontent.com/5793815/82565885-0c696700-9b73-11ea-9240-da3185bf9fa8.png)

#### No further action required
![confirmation_page_no_action](https://user-images.githubusercontent.com/5793815/82565781-e0e67c80-9b72-11ea-8d9e-6f16fc8d6eb1.png)

### Confirmation email
#### Contact GP
![confirmation_email_contact_gp](https://user-images.githubusercontent.com/5793815/82565954-26a34500-9b73-11ea-89c7-5ba62ca63f17.png)

#### No further action required
![confirmation_email_no_action](https://user-images.githubusercontent.com/5793815/82565981-2efb8000-9b73-11ea-9242-d7a3797a8a1b.png)

### Confirmation SMS
#### Contact GP
![confirmation_sms_contact_gp](https://user-images.githubusercontent.com/5793815/82566047-433f7d00-9b73-11ea-86f2-1a5b6eb1c47a.jpg)

#### No further action required
![confirmation_no_action_sms](https://user-images.githubusercontent.com/5793815/82566074-4e92a880-9b73-11ea-9c26-aa623f19eba2.jpg)

## How to test locally
Follow the instructions here to be able to test email and sms locally: https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/309/commits/f0d3fbd8afad38ecc801c9e80b625deb0db796c8