### PR TITLE
Fix phone number validation

### DIFF
--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -104,7 +104,7 @@ module FieldValidationHelper
   end
 
   def validate_telephone_number(field, telephone_number)
-    if TelephoneNumber.parse(telephone_number, :gb).valid?
+    if TelephoneNumber.parse(telephone_number.gsub(/\s+/, ""), :gb).valid?
       []
     else
       [{ field: field.to_s, text: t("coronavirus_form.errors.telephone_number_format") }]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,7 +247,7 @@ en:
       postcode_format: "Enter a real postcode"
       negative_date: "Enter a real %{field}"
       date_not_a_number: "Enter %{field} as a number"
-      telephone_number_format: "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192"
+      telephone_number_format: "Enter a telephone number, like 020 7946 0000, 07700900000 or +44 0808 157 0192"
     confirmation:
       title: Registration complete
       description: |

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
 
   let(:current_template) { "coronavirus_form/contact_details" }
   let(:session_key) { :contact_details }
+  let(:next_question_path) { know_nhs_number_path }
 
   describe "GET show" do
     it "renders the form" do
@@ -58,13 +59,25 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: params
-      expect(response).to redirect_to(know_nhs_number_path)
+      expect(response).to redirect_to next_question_path
     end
 
     it "does not move to next step with an invalid phone number for calls" do
       post :submit, params: { "phone_number_calls": "1234" }
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
+    end
+
+    [
+      "02033 445 566", "07711 330 382", "+44 0808 157 0192",
+      "07788990011", "077889 90011", "+447788990011",
+      "+44 77889 90011"
+    ].each do |number|
+      it "permits the valid phone number #{number}" do
+        post :submit, params: { "phone_number_calls": number }
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to next_question_path
+      end
     end
 
     it "does not move to next step with an invalid phone number for text messages" do


### PR DESCRIPTION
Currently we don't accept some real phone numbers, including phone numbers in the format we use in our error message.

For some reason Github won't let me upload the screenshot of the error.

This change allows phone numbers to contain whitespace. The [TelephoneNumber](https://github.com/mobi/telephone_number) gem was rejecting numbers with whitespace. Additionally, some of our tests contained invalid phone numbers.

https://trello.com/c/JXUKXuf2/375-make-phone-number-field-more-permissive