### PR TITLE
Add more detail to documentation

### DIFF
--- a/docs/external_apis/ordnance_survey.md
+++ b/docs/external_apis/ordnance_survey.md
@@ -2,15 +2,27 @@
 
 Used by: AddressHelper::postcode_lookup
 
-The Ordnance Survey Places API returns a list of UPRNs and specific address for a given postcode.
+The [Ordnance Survey Places API](https://apidocs.os.uk/docs/os-places-technical-detail) returns a list of Unique Property Reference Numbers (UPRN) for a given postcode.
 
-The default response excludes flats that do not have their own street address. To include them, `dataset=LPI` has been added to the query string.
+Why a list? Because relatively few postcodes indicate a single 'real'<sup>*</sup> address. The majority of postcodes cover multiple 'real' addresses within a single postcode.
 
-`LPI` gives additional non-postcode address information - i.e. the bottom chunk for 10 downing st.  The default, `DPA` is limited to valid postcodes relating to that address only.
+Additionally, a postcode may also include non-addresses.  These are addresses that are covered by the postcode, but are **not** locations to which mail can be directed or delivered. In essence, a location to which the postal service does not have access. Such addresses are  indicated in the API response by having their `POSTAL_ADDRESS_CODE_DESCRIPTION` field set to `Not a postal address`.
 
-e.g. https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?dataset=LPI&postcode=SW1A2AA&key=<ORDNANCE_SURVEY_PLACES_API_KEY>
+To indicate this difference, the Places API offers two different datasets - or response types:
 
-`ORDNANCE_SURVEY_PLACES_API_KEY` is defined in `govuk-secrets`
+* `DPA` - is the default response dataset and only includes addresses that **are** 'real',
+* `LPI` - this dataset includes all addresses for a given postcode - including the non-'real' ones.
 
+To indicate to the API which dataset you are interested in receiving, a query string parameter is added - `dataset=DPA` or `dataset=LPI`.  As `DPA` is the default, `dataset=DPA` can be omitted from the query string.
 
-See [Ordnance Survey places API documentation](https://apidocs.os.uk/docs/os-places-technical-detail) for more information.
+For our purposes, we need the Places API to respond with `LPI` dataset entries.
+
+For example...
+
+```
+https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?dataset=LPI&postcode=SW1A2AA&key=<ORDNANCE_SURVEY_PLACES_API_KEY>
+```
+
+The `ORDNANCE_SURVEY_PLACES_API_KEY` is defined in `govuk-secrets`.  You will require this API key should you need to (re)generate the VCR cassette saved API responses.
+
+<sup>*</sup> A location to which a corespondent can direct mail, and to which that mail can be delivered.

--- a/docs/testing/testing_with_vcr.md
+++ b/docs/testing/testing_with_vcr.md
@@ -1,20 +1,24 @@
 # Testing with VCR
 
-We use [VCR](https://github.com/vcr/vcr) to record actual responses from an external API, and then use these responses to test our code, rather than manually creating stubs of the expected response.
+> "Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests."
 
-At the moment VCR is only being used in the AddressHelper specs to test how responses from the [Ordnance Survey places API](https://apidocs.os.uk/docs/os-places-technical-detail) are used to do a postcode lookup.
+We are using [VCR](https://github.com/vcr/vcr) to record actual responses from an external API, and then use these saved responses (or cassette's as VCR calls them) to test our code, rather than manually creating stubs of the expected response.
+
+Currently, VCR is only being used in the AddressHelper specs to test postcode lookup responses from the [Ordnance Survey places API](https://apidocs.os.uk/docs/os-places-technical-detail).
 
 ## Recording a new response
 
-If you think the data may have changed, then you'll need to record a new response.
+If you think the data may have changed, then you may need to record a new response from the actual API.  
 
-1. Update this entry in `config/application.rb` with the real value from secrets:
+To do this...
+
+1. Update the `ORDNANCE_SURVEY_PLACES_API_KEY` environment variable in `config/application.rb` with the real API key from secrets:
 
 ```
 ENV["ORDNANCE_SURVEY_PLACES_API_KEY"] = "123"
 ```
 
-2. . Update the test to record a new response
+2. Update the test to record a new response
 i.e. Change:
 
 ```
@@ -26,17 +30,18 @@ to:
 VCR.use_cassette "address/500_response", record: :new_episodes do
 ```
 
-4. Run the test again
-5. The "cassette" e.g. `spec/vcr/address/500_response` should have a new response entry.
-6. Revert changes made in steps 1 - 3.
+3. Run the test again
+4. The "cassette" e.g. `spec/vcr/address/500_response` should now have a new response entry.
+5. Revert changes made in steps 1 and 2.
 
+If you need to update **all** of the saved API responses - the best way is to simply delete the `address` directory - including all `.rb` files under it - within `spec/vcr`. Then re-run either the `spec/helpers/address_helper_spec.rb` test or all tests.
 
 ## Troubleshooting
 If something goes wrong, VCR will throw a `VCR::Errors::UnhandledHTTPRequestError` error.
 
 To see the stack trace, add a `binding.pry` to the test and run the code you're trying to test. VCR gives a very detailed description of what went wrong.
 
-Things to check are things like copy and paste errors. Make sure the querystring parameters exactly match what's in the cassette under:
+Things to check for are copy and paste errors for example. Make sure the query string parameters exactly match what's in the cassette under:
 
 ```
 http_interactions:


### PR DESCRIPTION
Update and add additional information about VCR and its use.  Some areas need clarification - fix a few typos.

Update and add additional information about the Ordnance Survey API and its responses.  Generally needed fleshing out a bit, especially the area around the distinction around real and non-real addresses and the choice of dataset.

[Trello](https://trello.com/c/vNvs7KKo/392-add-more-detail-to-developer-documentation)
