### PR TITLE
Retry on Notifications::Client::AuthError

### DIFF
--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -5,6 +5,10 @@ class EmailDeliveryJob < ActionMailer::DeliveryJob
 
   discard_on Notifications::Client::BadRequestError
 
+  retry_on(Notifications::Client::AuthError,
+           wait: :exponentially_longer,
+           attempts: 5)
+
   retry_on(Notifications::Client::RequestError,
            wait: :exponentially_longer,
            attempts: 5)


### PR DESCRIPTION
What
----

As part of the request to Notify when we send confirmation emails (and soon SMS messages), we send a current timestamp as part of a JWT token (this is done by the `notifications-ruby-client` gem for us).  If the timestamp is not within 30 seconds, Notify returns an unauthorised error, which raises `Notifications::Client::AuthError` in our
applications.

We have found a small number of cases where the request to Notify takes longer than 30 seconds to open, therefore the timestamp is now out of date and Notify rejects the request.  In these cases, we should retry the request to ensure the email is actually sent to the user and we
don't log the error unless it keeps occurring.

How to review
-------------

This should just require code review.

I have changed the approach from that listed in the Trello card.  If I added a timeout, we still wouldn't be retrying the job which means the user would never receive the email.

Links
-----

Trello card: https://trello.com/c/9sejZucy