### PR TITLE
Use consistent quotes for translations in views

### DIFF
--- a/app/views/coronavirus_form/accessibility_statement.html.erb
+++ b/app/views/coronavirus_form/accessibility_statement.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title do %><%= t('accessibility_statement.title') %><% end %>
+<% content_for :title do %><%= t("accessibility_statement.title") %><% end %>
 
 <%= render "govuk_publishing_components/components/title", {
   title:t("accessibility_statement.title"),
   margin_top: 0
 } %>
 
-<%= sanitize(t('accessibility_statement.body_text')) %>
+<%= sanitize(t("accessibility_statement.body_text")) %>

--- a/app/views/coronavirus_form/basic_care_needs.erb
+++ b/app/views/coronavirus_form/basic_care_needs.erb
@@ -2,7 +2,7 @@
   <%= t("coronavirus_form.questions.basic_care_needs.title") %>
 <% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.basic_care_needs.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.basic_care_needs.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>

--- a/app/views/coronavirus_form/carry_supplies.html.erb
+++ b/app/views/coronavirus_form/carry_supplies.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.carry_supplies.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.carry_supplies.title") %>" />
 <% end %>
 
     <% content_for :back_link do %>

--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -1,27 +1,27 @@
-<% content_for :title do %><%= t('check_your_answers.title') %><% end %>
+<% content_for :title do %><%= t("check_your_answers.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('check_your_answers.title') %>" />
+  <meta name="description" content="<%= t("check_your_answers.title") %>" />
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: t('check_your_answers.title'),
+  title: t("check_your_answers.title"),
   margin_top: 0,
   margin_bottom: 3,
 } %>
 
-<%= tag.p t('check_your_answers.description'), class: "govuk-body" %>
+<%= tag.p t("check_your_answers.description"), class: "govuk-body" %>
 
 <%= render "govuk_publishing_components/components/summary_list", {
   items: answer_items,
 } %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: t('check_your_answers.heading'),
+  text: t("check_your_answers.heading"),
   heading_level: 2,
   margin_bottom: 3,
 } %>
 
-<%= tag.p t('check_your_answers.confirmation'), class: "govuk-body" %>
+<%= tag.p t("check_your_answers.confirmation"), class: "govuk-body" %>
 
 <%= form_tag({},
   "data-module": "track-coronavirus-form-vulnerable-people-check_your_answers",
@@ -29,6 +29,6 @@
   "novalidate": "true"
 ) do %>
   <%= render "govuk_publishing_components/components/button",
-    text: t('check_your_answers.submit'),
+    text: t("check_your_answers.submit"),
     margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/confirmation.html.erb
+++ b/app/views/coronavirus_form/confirmation.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.confirmation.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.confirmation.title") %><% end %>
 <%= render "govuk_publishing_components/components/panel", {
   title: t("coronavirus_form.confirmation.title")
 } %>
 
-<%= sanitize(t('coronavirus_form.confirmation.description')) %>
+<%= sanitize(t("coronavirus_form.confirmation.description")) %>

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.contact_details.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.contact_details.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>

--- a/app/views/coronavirus_form/cookies.html.erb
+++ b/app/views/coronavirus_form/cookies.html.erb
@@ -25,7 +25,7 @@
     margin_top: 0,
   } %>
 
-  <%= tag.p t('cookies.settings_page.intro_html'), class: "govuk-body" %>
+  <%= tag.p t("cookies.settings_page.intro_html"), class: "govuk-body" %>
 
   <div class="cookie-settings__no-js">
     <%= render "govuk_publishing_components/components/govspeak", {
@@ -38,7 +38,7 @@
     <% end %>
   </div>
 
-  <% t('cookies.settings_page.tables').map do |table| %>
+  <% t("cookies.settings_page.tables").map do |table| %>
     <div class="cookie-settings__table-wrapper">
       <%= render "govuk_publishing_components/components/heading", {
         text: sanitize(table.dig(:header)),
@@ -63,7 +63,7 @@
         inline: false,
         heading: t("cookies.settings_page.cookie_options.header"),
         # hint: (cookies_usage_hint),
-        items: t('cookies.settings_page.cookie_options').fetch(:options, []),
+        items: t("cookies.settings_page.cookie_options").fetch(:options, []),
         margin_top: 0,
       } %>
 

--- a/app/views/coronavirus_form/date_of_birth.html.erb
+++ b/app/views/coronavirus_form/date_of_birth.html.erb
@@ -2,7 +2,7 @@
   <%= t("coronavirus_form.questions.date_of_birth.title") %>
 <% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.date_of_birth.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.date_of_birth.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>

--- a/app/views/coronavirus_form/dietary_requirements.html.erb
+++ b/app/views/coronavirus_form/dietary_requirements.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.dietary_requirements.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.dietary_requirements.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>

--- a/app/views/coronavirus_form/live_in_england.html.erb
+++ b/app/views/coronavirus_form/live_in_england.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.live_in_england.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.live_in_england.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.live_in_england.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.live_in_england.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -13,11 +13,11 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.live_in_england.title'),
+  heading: t("coronavirus_form.questions.live_in_england.title"),
   is_page_heading: true,
   name: "live_in_england",
   error_message: error_items('live_in_england'),
-  items: t('coronavirus_form.questions.live_in_england.options').map.with_index do |(_, item), index|
+  items: t("coronavirus_form.questions.live_in_england.options").map.with_index do |(_, item), index|
     {
       id: ("live_in_england" if index == 0),
       value: item[:label],

--- a/app/views/coronavirus_form/medical_conditions.html.erb
+++ b/app/views/coronavirus_form/medical_conditions.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.medical_conditions.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.medical_conditions.title") %><% end %>
     <% content_for :meta_tags do %>
-      <meta name="description" content="<%= t('coronavirus_form.questions.medical_conditions.title') %>" />
+      <meta name="description" content="<%= t("coronavirus_form.questions.medical_conditions.title") %>" />
     <% end %>
 
     <% content_for :back_link do %>
@@ -9,7 +9,7 @@
 
     <% description_html = capture do %>
       <%= render "govuk_publishing_components/components/inset_text" do %>
-         <%= sanitize(t('coronavirus_form.questions.medical_conditions.description')) %>
+         <%= sanitize(t("coronavirus_form.questions.medical_conditions.description")) %>
       <% end %>
     <% end %>
 
@@ -25,7 +25,7 @@
       name: "medical_conditions",
       error_message: error_items('medical_conditions'),
       description: description_html,
-      items: t('coronavirus_form.questions.medical_conditions.options').map.with_index do |(_, item), index|
+      items: t("coronavirus_form.questions.medical_conditions.options").map.with_index do |(_, item), index|
         {
           id: ("medical_conditions" if index == 0),
           value: item[:label],

--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.name.title') %>">
+  <meta name="description" content="<%= t("coronavirus_form.questions.name.title") %>">
 <% end %>
 
 <% content_for :back_link do %>

--- a/app/views/coronavirus_form/nhs_letter.html.erb
+++ b/app/views/coronavirus_form/nhs_letter.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.nhs_letter.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.nhs_letter.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>

--- a/app/views/coronavirus_form/nhs_number.html.erb
+++ b/app/views/coronavirus_form/nhs_number.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.nhs_number.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.nhs_number.title") %><% end %>
     <% content_for :meta_tags do %>
-      <meta name="description" content="<%= t('coronavirus_form.questions.nhs_number.title') %>" />
+      <meta name="description" content="<%= t("coronavirus_form.questions.nhs_number.title") %>" />
       <%# stop iOS treating the NHS number as a phone number %>
       <meta name="format-detection" content="telephone=no" />
     <% end %>

--- a/app/views/coronavirus_form/not_eligible_england.html.erb
+++ b/app/views/coronavirus_form/not_eligible_england.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('not_eligible_england.title') %><% end %>
+<% content_for :title do %><%= t("not_eligible_england.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('not_eligible_england.title') %>" />
+  <meta name="description" content="<%= t("not_eligible_england.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -8,7 +8,7 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: t('not_eligible_england.title'),
+  title: t("not_eligible_england.title"),
   margin_top: 0
 } %>
-<%= sanitize(t('not_eligible_england.description')) %>
+<%= sanitize(t("not_eligible_england.description")) %>

--- a/app/views/coronavirus_form/not_eligible_medical.html.erb
+++ b/app/views/coronavirus_form/not_eligible_medical.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('not_eligible_medical.title') %><% end %>
+<% content_for :title do %><%= t("not_eligible_medical.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('not_eligible_medical.title') %>" />
+  <meta name="description" content="<%= t("not_eligible_medical.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -8,7 +8,7 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: t('not_eligible_medical.title'),
+  title: t("not_eligible_medical.title"),
   margin_top: 0
 } %>
-<%= sanitize(t('not_eligible_medical.description')) %>
+<%= sanitize(t("not_eligible_medical.description")) %>

--- a/app/views/coronavirus_form/privacy.html.erb
+++ b/app/views/coronavirus_form/privacy.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title do %><%= t('privacy_page.title') %><% end %>
+<% content_for :title do %><%= t("privacy_page.title") %><% end %>
 
 <%= render "govuk_publishing_components/components/title", {
   title:t("privacy_page.title"),
   margin_top: 0
 } %>
 
-<%= sanitize(t('privacy_page.body_text')) %>
+<%= sanitize(t("privacy_page.body_text")) %>

--- a/app/views/coronavirus_form/session_expired.html.erb
+++ b/app/views/coronavirus_form/session_expired.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('session_expired.title') %><% end %>
+<% content_for :title do %><%= t("session_expired.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('session_expired.title') %>" />
+  <meta name="description" content="<%= t("session_expired.title") %>" />
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
@@ -8,7 +8,7 @@
   margin_top: 0
 } %>
 
-<%= sanitize(t('session_expired.body_text')) %>
+<%= sanitize(t("session_expired.body_text")) %>
 
 <%= render "govuk_publishing_components/components/button", {
   text: "Start now",

--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.support_address.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.support_address.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -27,7 +27,7 @@
 ) do %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.support_address.building_and_street.label')
+    text: t("coronavirus_form.questions.support_address.building_and_street.label")
   },
   id: "building_and_street_line_1",
   name: "building_and_street_line_1",
@@ -38,7 +38,7 @@
 } %>
 
 <label class="govuk-visually-hidden" for="building_and_street_line_2">
-  <%= t('coronavirus_form.questions.support_address.building_and_street_line_2.label') %>
+  <%= t("coronavirus_form.questions.support_address.building_and_street_line_2.label") %>
 </label>
 <%= render "govuk_publishing_components/components/input", {
   id: "building_and_street_line_2",
@@ -50,7 +50,7 @@
 
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.support_address.town_city.label')
+    text: t("coronavirus_form.questions.support_address.town_city.label")
   },
   id: "town_city",
   name: "town_city",
@@ -63,7 +63,7 @@
 
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.support_address.county.label')
+    text: t("coronavirus_form.questions.support_address.county.label")
   },
   id: "county",
   name: "county",
@@ -75,7 +75,7 @@
 
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.support_address.postcode.label')
+    text: t("coronavirus_form.questions.support_address.postcode.label")
   },
   id: "postcode",
   name: "postcode",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8" />
-    <title><%= t('coronavirus_form.errors.page_title_prefix') if flash[:validation]&.any? %><%= yield :title %> - GOV.UK</title>
+    <title><%= t("coronavirus_form.errors.page_title_prefix") if flash[:validation]&.any? %><%= yield :title %> - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <meta name="robots" content="noindex nofollow">


### PR DESCRIPTION
In some places we are using double quotes, and in other places we are using single quotes when including translations in the views.

In the absence of view linting, updating to make this consistent in all views.