### PR TITLE
Redirect GET /start to first_question

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   get "/", to: redirect("https://www.gov.uk/coronavirus-extremely-vulnerable")
 
   scope module: "coronavirus_form" do
+    get "/start", to: redirect("/live-in-england")
+
     get "/privacy", to: "privacy#show"
     get "/accessibility-statement", to: "accessibility_statement#show"
     get "/cookies", to: "cookies#show"

--- a/spec/requests/start_spec.rb
+++ b/spec/requests/start_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe "start" do
+  describe "GET /start" do
+    it "redirects to the first question" do
+      get start_path
+      expect(response).to redirect_to live_in_england_path
+    end
+  end
+end


### PR DESCRIPTION
What
----

- ~Aliased "/live_in_england" as a `first_question` variable so it can be changed once in future~ 
Unlike other PRs on other apps i've not done this here as the redirects are done in the controllers for the moment. 

- Add a redirect from `/start` to `live_in_england` with request test.

How to review
-------------

Once this is up we'll be able to point start pages at the `/start` route permenantly. Start routes are outside of the app and so easy to miss whenever we update a first question.

This has occured in the past and this ticket is a follow on action from a previous incidnet.

Links
-----

[Trello Create a `/start` path to redirect to first question](https://trello.com/c/HoPfPgbX/396-create-a-start-path-to-redirect-to-first-question),
