### PR TITLE
Add information on timings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,7 +216,7 @@ en:
 
         If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.
 
-        This can take up to a week - or longer if you haven't had the letter from your NHS or from your doctor. Contact your local authority if you need supplies urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/find-local-council   
+        This can take up to a week - or longer if you haven’t had the letter from your NHS or from your doctor. Contact your local authority if you need supplies urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/find-local-council   
 
         ## If your support needs change
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,8 @@ en:
 
         If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.
 
+        This can take up to a week - or longer if you haven't had the letter from your NHS or from your doctor. Contact your local authority if you need supplies urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/find-local-council   
+
         ## If your support needs change
 
         You can tell the delivery driver if you want to stop getting the weekly box of supplies.
@@ -262,7 +264,7 @@ en:
         <p class="govuk-body">If you’re eligible and you said that you do not have a way of getting basic supplies at the moment we will start sending you a weekly box of basic supplies.</p>
         <p class="govuk-body">We’ll also share your details with participating supermarkets to help them prioritise you for their delivery services.</p>
         <p class="govuk-body">If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.</p>
-        <p class="govuk-body">It may take some time before you start getting support. <a class="govuk-link" href="https://www.gov.uk/find-local-council">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
+        <p class="govuk-body">This can take up to a week - or longer if you haven't had the letter from your NHS or from your doctor. <a class="govuk-link" href="https://www.gov.uk/find-local-council">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
         <h2 class="govuk-heading-m">If your support needs change</h2>
         <p class="govuk-body">You can tell the delivery driver if you want to stop getting the weekly box of supplies.</p>
         <p class="govuk-body">If your support needs change, <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,7 +264,7 @@ en:
         <p class="govuk-body">If you’re eligible and you said that you do not have a way of getting basic supplies at the moment we will start sending you a weekly box of basic supplies.</p>
         <p class="govuk-body">We’ll also share your details with participating supermarkets to help them prioritise you for their delivery services.</p>
         <p class="govuk-body">If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.</p>
-        <p class="govuk-body">This can take up to a week - or longer if you haven't had the letter from your NHS or from your doctor. <a class="govuk-link" href="https://www.gov.uk/find-local-council">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
+        <p class="govuk-body">This can take up to a week - or longer if you haven’t had the letter from your NHS or from your doctor. <a class="govuk-link" href="https://www.gov.uk/find-local-council">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
         <h2 class="govuk-heading-m">If your support needs change</h2>
         <p class="govuk-body">You can tell the delivery driver if you want to stop getting the weekly box of supplies.</p>
         <p class="govuk-body">If your support needs change, <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>


### PR DESCRIPTION
Add information on how long getting support is likely to take to the confirmation screen and confirmation email

https://trello.com/c/mrGqdydz/412-add-timing-info-to-confirmation-messages

