### PR TITLE
Accept `session_id` in the schema

### DIFF
--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -161,6 +161,9 @@
     },
     "_csrf_token": {
       "type": "string"
+    },
+    "session_id": {
+      "type": "string"
     }
   },
   "definitions": {

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -318,6 +318,11 @@ RSpec.describe SchemaHelper, type: :helper do
         data = valid_data.merge(previous_path: "/foo")
         expect(validate_against_form_response_schema(data)).to be_empty
       end
+
+      it "allows the session_id to be stored" do
+        data = valid_data.merge(session_id: SecureRandom.uuid)
+        expect(validate_against_form_response_schema(data)).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/329

It looks like `session_id` is being stored in the session, and therefore propagated to the DB.

Should fix: https://sentry.io/organizations/govuk/issues/1667664108/?project=5170680&referrer=slack