### PR TITLE
Task/add sidekick information to prometheus

### DIFF
--- a/helpers/application_config.rb
+++ b/helpers/application_config.rb
@@ -1,5 +1,5 @@
 require "prometheus/middleware/collector"
-require "sidekiq_stats_prometheus_exporter"
+require "./lib/sidekiq_stats_prometheus_exporter"
 
 class ApplicationConfig
   def self.call

--- a/helpers/application_config.rb
+++ b/helpers/application_config.rb
@@ -1,5 +1,5 @@
 require "prometheus/middleware/collector"
-require "prometheus/middleware/exporter"
+require "sidekiq_stats_prometheus_exporter"
 
 class ApplicationConfig
   def self.call
@@ -8,7 +8,7 @@ class ApplicationConfig
 
       map "/metrics" do
         use Rack::Deflater
-        use Prometheus::Middleware::Exporter, path: ""
+        use SidekiqStatsPrometheusExporter, path: ""
         run ->(_) { [500, { "Content-Type" => "text/html" }, ["Metrics endpoint is unreachable!"]] }
       end
 

--- a/lib/sidekiq_stats_prometheus_exporter.rb
+++ b/lib/sidekiq_stats_prometheus_exporter.rb
@@ -1,39 +1,37 @@
 require "sidekiq/api"
 require "prometheus/middleware/exporter"
 
-module Services
-  class SidekiqStatsPrometheusExporter < Prometheus::Middleware::Exporter
-    def initialize(app, options = {})
-      super(app, options)
+class SidekiqStatsPrometheusExporter < Prometheus::Middleware::Exporter
+  def initialize(app, options = {})
+    super(app, options)
 
-      @prometheus = Prometheus::Client.registry
+    @prometheus = Prometheus::Client.registry
 
-      @sidekiq_total_processed_jobs = @prometheus.gauge(:sidekiq_processed_jobs, docstring: "The number of jobs processed by sidekiq")
-      @sidekiq_total_failed_jobs = @prometheus.gauge(:sidekiq_failed_jobs, docstring: "The number of failed sidekick jobs")
-      @sidekiq_total_dead_jobs = @prometheus.gauge(:sidekiq_dead_jobs, docstring: "The number of jobs dead sidekiq jobs")
-      @sidekiq_mailers_queue_size = @prometheus.gauge(:sidekiq_mailers_queue_size, docstring: "The number of jobs in the 'mailers' queue")
-      @sidekiq_mailers_queue_latency = @prometheus.gauge(:sidekiq_mailers_queue_latency, docstring: "The latency of the sideqkiq 'mailers' queue")
-    end
+    @sidekiq_total_processed_jobs = @prometheus.gauge(:sidekiq_processed_jobs, docstring: "The number of jobs processed by sidekiq")
+    @sidekiq_total_failed_jobs = @prometheus.gauge(:sidekiq_failed_jobs, docstring: "The number of failed sidekick jobs")
+    @sidekiq_total_dead_jobs = @prometheus.gauge(:sidekiq_dead_jobs, docstring: "The number of jobs dead sidekiq jobs")
+    @sidekiq_mailers_queue_size = @prometheus.gauge(:sidekiq_mailers_queue_size, docstring: "The number of jobs in the 'mailers' queue")
+    @sidekiq_mailers_queue_latency = @prometheus.gauge(:sidekiq_mailers_queue_latency, docstring: "The latency of the sideqkiq 'mailers' queue")
+  end
 
-    def gather_sidekick_metrics
-      stats = Sidekiq::Stats.new
-      mailer_queue = Sidekiq::Queue.new("mailers")
-      @sidekiq_total_processed_jobs.set(stats.processed)
-      @sidekiq_total_failed_jobs.set(stats.failed)
-      @sidekiq_total_dead_jobs.set(stats.dead_size)
-      @sidekiq_mailers_queue_size.set(mailer_queue.size)
-      @sidekiq_mailers_queue_latency.set(mailer_queue.latency)
-    rescue StandardError => e
-      Rails.logger.error ["Error gathering sidekiq stats", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
-    end
+  def gather_sidekick_metrics
+    stats = Sidekiq::Stats.new
+    mailer_queue = Sidekiq::Queue.new("mailers")
+    @sidekiq_total_processed_jobs.set(stats.processed)
+    @sidekiq_total_failed_jobs.set(stats.failed)
+    @sidekiq_total_dead_jobs.set(stats.dead_size)
+    @sidekiq_mailers_queue_size.set(mailer_queue.size)
+    @sidekiq_mailers_queue_latency.set(mailer_queue.latency)
+  rescue StandardError => e
+    Rails.logger.error ["Error gathering sidekiq stats", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
+  end
 
-    def respond_with(format)
-      gather_sidekick_metrics
-      [
-        200,
-        { "Content-Type" => format::CONTENT_TYPE },
-        [format.marshal(@registry)],
-      ]
-    end
+  def respond_with(format)
+    gather_sidekick_metrics
+    [
+      200,
+      { "Content-Type" => format::CONTENT_TYPE },
+      [format.marshal(@registry)],
+    ]
   end
 end

--- a/lib/sidekiq_stats_prometheus_exporter.rb
+++ b/lib/sidekiq_stats_prometheus_exporter.rb
@@ -1,0 +1,39 @@
+require "sidekiq/api"
+require "prometheus/middleware/exporter"
+
+module Services
+  class SidekiqStatsPrometheusExporter < Prometheus::Middleware::Exporter
+    def initialize(app, options = {})
+      super(app, options)
+
+      @prometheus = Prometheus::Client.registry
+
+      @sidekiq_total_processed_jobs = @prometheus.gauge(:sidekiq_processed_jobs, docstring: "The number of jobs processed by sidekiq")
+      @sidekiq_total_failed_jobs = @prometheus.gauge(:sidekiq_failed_jobs, docstring: "The number of failed sidekick jobs")
+      @sidekiq_total_dead_jobs = @prometheus.gauge(:sidekiq_dead_jobs, docstring: "The number of jobs dead sidekiq jobs")
+      @sidekiq_mailers_queue_size = @prometheus.gauge(:sidekiq_mailers_queue_size, docstring: "The number of jobs in the 'mailers' queue")
+      @sidekiq_mailers_queue_latency = @prometheus.gauge(:sidekiq_mailers_queue_latency, docstring: "The latency of the sideqkiq 'mailers' queue")
+    end
+
+    def gather_sidekick_metrics
+      stats = Sidekiq::Stats.new
+      mailer_queue = Sidekiq::Queue.new("mailers")
+      @sidekiq_total_processed_jobs.set(stats.processed)
+      @sidekiq_total_failed_jobs.set(stats.failed)
+      @sidekiq_total_dead_jobs.set(stats.dead_size)
+      @sidekiq_mailers_queue_size.set(mailer_queue.size)
+      @sidekiq_mailers_queue_latency.set(mailer_queue.latency)
+    rescue StandardError => e
+      Rails.logger.error ["Error gathering sidekiq stats", e.message, *e.backtrace].join($INPUT_RECORD_SEPARATOR)
+    end
+
+    def respond_with(format)
+      gather_sidekick_metrics
+      [
+        200,
+        { "Content-Type" => format::CONTENT_TYPE },
+        [format.marshal(@registry)],
+      ]
+    end
+  end
+end

--- a/spec/requests/view_metrics_spec.rb
+++ b/spec/requests/view_metrics_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "prometheus metrics", type: :request do
       get "/metrics"
 
       expect(last_response).to be_ok
+      expect(last_response.body).to match(/sidekiq/)
     end
   end
 end


### PR DESCRIPTION
### Changes

The requirements around what metrics should be provided, and what they were to be used for was slightly ambiguous, so this PR endeavours to match the requirements to what is provided by `Sidekiq::Stats`. What follows is a description.

**Required metric:** Time to send an email

**Provided:** [Queue latency](https://www.rubydoc.info/github/mperham/sidekiq/Sidekiq%2FQueue:latency) for the email queue (**prometheus metric name:** `sidekiq_mailers_queue_latency`). This is a rough indicator of the time it will take to send a given email from the moment it is queued. 

**Required metric:** Email job failure rate

**Provided:** Job failure rate for sidekiq as a whole (**prometheus metric name:** `sidekiq_failed_jobs`) and in addition a count of the dead sidekiq jobs (**prometheus metric name:** `sidekiq_dead_jobs`). The failure rate on a per job/queue basis is not data that is collected by sidekiq and is thus not available in the `Sidekiq::Stats` API. 

N.B: Currently the only job ran by the `govuk-coronavirus-vulnerable-people-form` service is the email job, so, for now, the two are equivalent.

**Required metric:** Email job volume

**Provided metric:** The volume of jobs in the email job queue (**prometheus metric name:** `sidekiq_mailers_queue_size`). Sidekiq doesn't keep records of the jobs that have been completed on a per queue basis, so historical information isn't available here. The same point as above re emails currently being the only job on the service holds true, and we provide the metric `sidekiq_processed_jobs` that tracks the total number of processed jobs.

### How to review

The metrics test has been extended to check that some sidekiq information is included, tests can be run the usual way via: 

`rake exec bundle`

In addition one can see the individual metrics by running:

`foreman start`  and going to `http://localhost:5000/metrics`

One can also configure a prometheus job to scrape the metrics endpoint, and observe that prometheus is picking up the metrics.

## Links

https://trello.com/c/QzchHd65/265-add-monitoring-for-sidekiq