### PR TITLE
Update links to find your local authority

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
     description: |
       <p class="govuk-body">This service is for people with one of the listed medical conditions or have been told by their GP or hospital clinician that they need to ‘shield’.</p>
       <p class="govuk-body">You can read <a class="govuk-link" href="https://www.gov.uk/coronavirus">general guidance on what you need to do</a>.</p>
-      <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/find-local-council">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
+      <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/coronavirus-local-help">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
       <p class="govuk-body">If your medical condition changes or your GP or hospital clinician tells you that you need to start ‘shielding’, go to <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">www.gov.uk/coronavirus-extremely-vulnerable</a> and go through the questions again.</p>
       <p class="govuk-body">We won’t store the information you entered into this service.</p>
       <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-extremely-vulnerable">Give feedback on this service</a>.</p>
@@ -216,7 +216,7 @@ en:
 
         If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.
 
-        This can take up to a week - or longer if you haven’t had the letter from your NHS or from your doctor. Contact your local authority if you need supplies urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/find-local-council   
+        This can take up to a week - or longer if you haven’t had the letter from your NHS or from your doctor. Contact your local authority if you need supplies urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help   
 
         ## If your support needs change
 
@@ -264,7 +264,7 @@ en:
         <p class="govuk-body">If you’re eligible and you said that you do not have a way of getting basic supplies at the moment we will start sending you a weekly box of basic supplies.</p>
         <p class="govuk-body">We’ll also share your details with participating supermarkets to help them prioritise you for their delivery services.</p>
         <p class="govuk-body">If you do not already have an account with a supermarket delivery service, set one up now. If you’re concerned about not being able to get a delivery slot, you can set up accounts with more than one supermarket.</p>
-        <p class="govuk-body">This can take up to a week - or longer if you haven’t had the letter from your NHS or from your doctor. <a class="govuk-link" href="https://www.gov.uk/find-local-council">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
+        <p class="govuk-body">This can take up to a week - or longer if you haven’t had the letter from your NHS or from your doctor. <a class="govuk-link" href="https://www.gov.uk/coronavirus-local-help">Contact your local authority</a> if you need supplies urgently and cannot rely on family, friends or neighbours.</p>
         <h2 class="govuk-heading-m">If your support needs change</h2>
         <p class="govuk-body">You can tell the delivery driver if you want to stop getting the weekly box of supplies.</p>
         <p class="govuk-body">If your support needs change, <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable">go through the questions in this service again</a>.</p>


### PR DESCRIPTION
Replace generic 'find your local council' links so they point to new, more specific service that's about finding coronavirus-specific help.

