### PR TITLE
Use `scss_lint-govuk` gem rather than `scss-lint`

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+plugin_gems: ["scss_lint-govuk"]

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ group :test do
   gem "capybara", "~> 3.32.1", require: false
   gem "climate_control"
   gem "mini_racer", "~> 0.2"
-  gem "scss-lint", "~> 0.7.0", require: false
   gem "selenium-webdriver"
   gem "simplecov", "~> 0.16"
   gem "vcr"
@@ -52,4 +51,5 @@ group :development, :test do
   gem "rails-controller-testing", "~> 1.0"
   gem "rspec-rails", "~> 4.0.0"
   gem "rubocop-govuk"
+  gem "scss_lint-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,6 @@ GEM
     childprocess (3.0.0)
     climate_control (0.2.0)
     coderay (1.1.2)
-    colorize (0.8.1)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     crack (0.4.3)
@@ -332,9 +331,10 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss-lint (0.7.0)
-      colorize
-      sass
+    scss_lint (0.59.0)
+      sass (~> 3.5, >= 3.5.5)
+    scss_lint-govuk (0.2.0)
+      scss_lint
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -420,7 +420,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0)
   rubocop-govuk
   sass-rails (< 6)
-  scss-lint (~> 0.7.0)
+  scss_lint-govuk
   selenium-webdriver
   sentry-raven (~> 3.0)
   sidekiq (~> 6.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,41 +3,42 @@
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
 
-@import 'govuk_publishing_components/components/_skip-link';
-@import 'govuk_publishing_components/components/_layout-header';
-@import 'govuk_publishing_components/components/_phase-banner';
-@import 'govuk_publishing_components/components/_back-link';
-@import 'govuk_publishing_components/components/_breadcrumbs';
+@import 'govuk_publishing_components/components/skip-link';
+@import 'govuk_publishing_components/components/layout-header';
+@import 'govuk_publishing_components/components/phase-banner';
+@import 'govuk_publishing_components/components/back-link';
+@import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/cookie-banner';
 
-@import 'govuk_publishing_components/components/_title';
-@import 'govuk_publishing_components/components/_heading';
-@import 'govuk_publishing_components/components/_inset-text';
+@import 'govuk_publishing_components/components/title';
+@import 'govuk_publishing_components/components/heading';
+@import 'govuk_publishing_components/components/inset-text';
 
-@import 'govuk_publishing_components/components/_error-message';
-@import 'govuk_publishing_components/components/_error-summary';
+@import 'govuk_publishing_components/components/error-message';
+@import 'govuk_publishing_components/components/error-summary';
 
-@import 'govuk_publishing_components/components/_layout-footer';
+@import 'govuk_publishing_components/components/layout-footer';
 
-@import 'govuk_publishing_components/components/_summary-list';
+@import 'govuk_publishing_components/components/summary-list';
 @import 'govuk_publishing_components/components/table';
-@import 'govuk_publishing_components/components/_panel';
+@import 'govuk_publishing_components/components/panel';
 
-@import 'govuk_publishing_components/components/_fieldset';
-@import 'govuk_publishing_components/components/_hint';
-@import 'govuk_publishing_components/components/_input';
-@import 'govuk_publishing_components/components/_date-input';
-@import 'govuk_publishing_components/components/_label';
-@import 'govuk_publishing_components/components/_radio';
-@import 'govuk_publishing_components/components/_button';
+@import 'govuk_publishing_components/components/fieldset';
+@import 'govuk_publishing_components/components/hint';
+@import 'govuk_publishing_components/components/input';
+@import 'govuk_publishing_components/components/date-input';
+@import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/radio';
+@import 'govuk_publishing_components/components/button';
 
 @import 'cookie-settings';
 
 .app-list--spaced > li {
-    margin-bottom: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
 }
+
 .app-list--spaced > li:last-child {
-    margin-bottom: govuk-spacing(0);
+  margin-bottom: govuk-spacing(0);
 }
 
 // The GOV.UK Design System team are aware of issues with lighter grey text for some disabled users
@@ -46,7 +47,7 @@
 
 // TODO: Try to allow passing through an app-hint class to the hint component
 .govuk-hint {
-    color: $govuk-text-colour
+  color: $govuk-text-colour;
 }
 
 // Make keys in Summary list easier to read on smaller screens.
@@ -54,13 +55,13 @@
 // TODO: Allow additional classes to be passed to the summary list component
 // We should be passing the .govuk-\!-width-two-thirds class instead of hardcoding it.
 .govuk-summary-list__key {
-    // https://github.com/alphagov/govuk-frontend/blob/v3.6.0/src/govuk/overrides/_width.scss#L18-L24
-    @include govuk-media-query($from: tablet) {
-        width: 66.66% !important;
-    }
+  // https://github.com/alphagov/govuk-frontend/blob/v3.6.0/src/govuk/overrides/_width.scss#L18-L24
+  @include govuk-media-query($from: tablet) {
+    width: 66.66% !important;
+  }
 }
 
 // TODO: Allow additional classes to pass to summary list link, or perhaps option to turn off visited state.
 .govuk-summary-list__actions-list-item > .govuk-link {
-    @include govuk-link-style-no-visited-state;
+  @include govuk-link-style-no-visited-state;
 }

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -3,6 +3,5 @@
 desc "Lint files"
 task "lint" => :environment do
   sh "rubocop --format clang"
-  # TODO: Figure out what Sass linting is failing on CI
-  # sh "scss-lint app/assets/stylesheets"
+  sh "scss-lint app/assets/stylesheets"
 end


### PR DESCRIPTION
What
----

- We should use our wrappers, as that's got GOV.UK-preferred config.
- Spotted this because of a Dependabot PR to bump `scss-lint` the
  upstream gem.

How to review
-------------

Observe that CI passes.

Links
-----

https://trello.com/c/0WEIi10A/450-use-scsslint-govuk-gem-rather-than-scss-lint

