### PR TITLE
Tighten up email validation

### DIFF
--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -86,7 +86,7 @@ module FieldValidationHelper
   end
 
   def validate_email_address(field, email_address)
-    if email_address =~ /(^[a-zA-Z0-9_.+\-]+@[a-zA-Z0-9\-]+\.[a-zA-Z0-9\-.]+$)/
+    if email_address.match?(URI::MailTo::EMAIL_REGEXP)
       []
     else
       [{ field: field.to_s, text: t("coronavirus_form.errors.email_format") }]


### PR DESCRIPTION
Trello: https://trello.com/c/Y7Yyko42

# What's changed?
Use the builtin REGEX to validate email addresses.
The builtin REGEX is more complex than the one we were using and catches the "..com" typo.

```
[1] pry(main)> URI::MailTo::EMAIL_REGEXP
=> /\A[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
```

e.g.

```
[4] pry(main)> "me@example.com".match?(URI::MailTo::EMAIL_REGEXP)
=> true
[5] pry(main)> "me@example.com".match?(/(^[a-zA-Z0-9_.+\-]+@[a-zA-Z0-9\-]+\.[a-zA-Z0-9\-.]+$)/)
=> true
[6] pry(main)> "me@example..com".match?(URI::MailTo::EMAIL_REGEXP)
=> false
[7] pry(main)> "me@example..com".match?(/(^[a-zA-Z0-9_.+\-]+@[a-zA-Z0-9\-]+\.[a-zA-Z0-9\-.]+$)/)
=> true
```
