### PR TITLE
Update SMS content

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,11 +197,9 @@ en:
       body_text: |
         We’ve received your registration as someone who’s clinically extremely vulnerable to coronavirus.
 
-        You do not need to do anything else if you’ve had a letter from the NHS or your doctor confirming that you’re clinically extremely vulnerable.
+        You do not need to do anything else if you’ve had a letter from the NHS or your doctor confirming that you’re clinically extremely vulnerable. If you haven’t, contact your GP as soon as possible. Otherwise you may not get support.
 
-        If you haven’t had a letter, contact your GP as soon as possible. Otherwise you may not get support.
-
-        We’ll check that you’re eligible, then you’ll start getting support if you asked for it.
+        We’ll check you’re eligible, then you’ll start getting support if you asked for it.
 
         This can take up to a week, or longer if you haven't had the letter from your NHS or from your doctor. Contact your local authority if you need urgent support and can’t rely on friends or neighbours.
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe I18n, type: :feature do
+  context "SMS content" do
+    it "all body text is less than or equal to 918 characters" do
+      I18n.t("sms").each do |_, sms_type|
+        expect(sms_type[:body_text].chomp.length).to be <= 918
+      end
+    end
+  end
+end


### PR DESCRIPTION
What
----

The confirmation SMS was one character too long (limit is 918 characters) which resulted in the message not sending when deploying to staging.

Therefore making two changes:
- Content shortened for confirmation SMS to be less than 918 characters
- Added a test for this (and all future) SMS content, to ensure we catch this before deploying

How to review
-------------

Review code and CI tests pass.

Links
-----

Trello card: https://trello.com/c/8L0b1iIg