### PR TITLE
Spike truemail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "sentry-raven", "~> 3.0"
 gem "sidekiq", "~> 6.0"
 gem "telephone_number", "~> 1.4"
 gem "timecop"
+gem "truemail", "~> 1.7.1"
 gem "uglifier", "~> 4.2"
 
 gem "prometheus-client", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,6 +349,8 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
+    simpleidn (0.1.1)
+      unf (~> 0.1.4)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -362,6 +364,8 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.1)
+    truemail (1.7.1)
+      simpleidn (~> 0.1.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -427,6 +431,7 @@ DEPENDENCIES
   simplecov (~> 0.16)
   telephone_number (~> 1.4)
   timecop
+  truemail (~> 1.7.1)
   uglifier (~> 4.2)
   vcr
   webdrivers

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -86,7 +86,7 @@ module FieldValidationHelper
   end
 
   def validate_email_address(field, email_address)
-    if email_address.match?(URI::MailTo::EMAIL_REGEXP)
+    if Truemail.valid?(email_address)
       []
     else
       [{ field: field.to_s, text: t("coronavirus_form.errors.email_format") }]

--- a/config/initializers/truemail.rb
+++ b/config/initializers/truemail.rb
@@ -1,0 +1,71 @@
+require "truemail"
+
+Truemail.configure do |config|
+  # Required parameter. Must be an existing email on behalf of which verification will be performed
+  config.verifier_email = "verifier@example.com"
+
+  # Optional parameter. Must be an existing domain on behalf of which verification will be performed.
+  # By default verifier domain based on verifier email
+  # config.verifier_domain = 'somedomain.com'
+
+  # Optional parameter. You can override default regex pattern
+  # config.email_pattern = /regex_pattern/
+
+  # Optional parameter. You can override default regex pattern
+  # config.smtp_error_body_pattern = /regex_pattern/
+
+  # Optional parameter. Connection timeout is equal to 2 ms by default.
+  # config.connection_timeout = 1
+
+  # Optional parameter. A SMTP server response timeout is equal to 2 ms by default.
+  # config.response_timeout = 1
+
+  # Optional parameter. Total of connection attempts. It is equal to 2 by default.
+  # This parameter uses in mx lookup timeout error and smtp request (for cases when
+  # there is one mx server).
+  # config.connection_attempts = 3
+
+  # Optional parameter. You can predefine default validation type for
+  # Truemail.validate('email@email.com') call without with-parameter
+  # Available validation types: :regex, :mx, :smtp
+  config.default_validation_type = :mx
+
+  # Optional parameter. You can predefine which type of validation will be used for domains.
+  # Also you can skip validation by domain. Available validation types: :regex, :mx, :smtp
+  # This configuration will be used over current or default validation type parameter
+  # All of validations for 'somedomain.com' will be processed with regex validation only.
+  # And all of validations for 'otherdomain.com' will be processed with mx validation only.
+  # It is equal to empty hash by default.
+  # config.validation_type_for = { 'somedomain.com' => :regex, 'otherdomain.com' => :mx }
+
+  # Optional parameter. Validation of email which contains whitelisted domain always will
+  # return true. Other validations will not processed even if it was defined in validation_type_for
+  # It is equal to empty array by default.
+  # config.whitelisted_domains = ['somedomain1.com', 'somedomain2.com']
+
+  # Optional parameter. With this option Truemail will validate email which contains whitelisted
+  # domain only, i.e. if domain whitelisted, validation will passed to Regex, MX or SMTP validators.
+  # Validation of email which not contains whitelisted domain always will return false.
+  # It is equal false by default.
+  # config.whitelist_validation = true
+
+  # Optional parameter. Validation of email which contains blacklisted domain always will
+  # return false. Other validations will not processed even if it was defined in validation_type_for
+  # It is equal to empty array by default.
+  # config.blacklisted_domains = ['somedomain1.com', 'somedomain2.com']
+
+  # Optional parameter. This option will provide to use not RFC MX lookup flow.
+  # It means that MX and Null MX records will be cheked on the DNS validation layer only.
+  # By default this option is disabled.
+  # config.not_rfc_mx_lookup_flow = true
+
+  # Optional parameter. This option will be parse bodies of SMTP errors. It will be helpful
+  # if SMTP server does not return an exact answer that the email does not exist
+  # By default this option is disabled, available for SMTP validation only.
+  # config.smtp_safe_check = true
+
+  # Optional parameter. This option will enable tracking events. You can print tracking events to
+  # stdout, write to file or both of these. Tracking event by default is :error
+  # Available tracking event: :all, :unrecognized_error, :recognized_error, :error
+  # config.logger = { tracking_event: :all, stdout: true, log_absolute_path: '/home/app/log/truemail.log' }
+end

--- a/config/initializers/truemail.rb
+++ b/config/initializers/truemail.rb
@@ -28,7 +28,7 @@ Truemail.configure do |config|
   # Optional parameter. You can predefine default validation type for
   # Truemail.validate('email@email.com') call without with-parameter
   # Available validation types: :regex, :mx, :smtp
-  config.default_validation_type = :mx
+  config.default_validation_type = :smtp
 
   # Optional parameter. You can predefine which type of validation will be used for domains.
   # Also you can skip validation by domain. Available validation types: :regex, :mx, :smtp

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       {
         "phone_number_calls" => "01234-578-890<script></script>",
         "phone_number_texts" => "+44(0)1876 543 210",
-        "email" => "<script></script>tester@example.org",
+        "email" => "<script></script>govuk-coronavirus-services@digital.cabinet-office.gov.uk",
       }
     end
 
@@ -32,7 +32,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       {
         phone_number_calls: "01234 578890",
         phone_number_texts: "01876 543210",
-        email: "tester@example.org",
+        email: "govuk-coronavirus-services@digital.cabinet-office.gov.uk",
       }
     end
 
@@ -91,7 +91,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
     end
 
     it "does not move to next step with an invalid email address" do
-      post :submit, params: { "email": "govuk-coronavirus-services@digital.cabinet_office,gov.uk" }
+      post :submit, params: { "email": "govuk-coronavirus-services@digital.cabinet-office,gov.uk" }
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
     end


### PR DESCRIPTION
Trello: https://trello.com/c/Y7Yyko42

# What?

Spike a way to catch most invalid email addresses by checking that the email exchange exists.

# Why?

Just using a regex doesn't seem to work as it lets some slip through the net.

As of 10th May, we have sent 83k confirmation emails to registrants on the vulnerable people service. Of these, almost 1,500 have failed due to incorrect email addresses.

Doing a very unscientific analysis of a few hundred failures, there seem to be some common typos:
- .con instead of .com
- .cpm instead of .com
- .cim instead of .com
- .cm instead of .com
- .couk instead of .co.uk
- hotail.co.uk instead of hotmail.co.uk
- fmail.com instead of gmail.com

Additionally, we have seen over 2.5k "invalid email address" validation responses from Notify through Sentry: https://sentry.io/organizations/govuk/issues/1646807753/?project=5170680&query=is%3Aunresolved

A very common issue in the Sentry errors is users entering two dots before com, possibly because they are using a .com button on their phone's keyboard.

In total, this means 3,600 people haven't received a confirmation email because they entered an invalid or incorrect email address.

One suggestion from the Design System is checking for common misspelling and warning the user.

# What's next?

If we decide to take this approach we need to do some work to determine what level of validation we want to use.
