### PR TITLE
Remove unnecessary keys from the FormResponse

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -94,7 +94,7 @@ private
   end
 
   def sanitised_session
-    session_with_indifferent_access.except(:session_id, :_csrf_token, :current_path, :previous_path, :check_answers_seen)
+    session_with_indifferent_access.except(:_csrf_token, :current_path, :previous_path, :check_answers_seen)
   end
 
   def contact_gp?

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -27,7 +27,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
       FormResponse.create(
         ReferenceId: submission_reference,
         UnixTimestamp: Time.zone.now,
-        FormResponse: session,
+        FormResponse: sanitised_session,
       )
 
       send_confirmation_email if session_with_indifferent_access.dig(:contact_details, :email).present?
@@ -91,6 +91,10 @@ private
 
   def session_with_indifferent_access
     session.to_h.with_indifferent_access
+  end
+
+  def sanitised_session
+    session_with_indifferent_access.except(:session_id, :_csrf_token, :current_path, :previous_path, :check_answers_seen)
   end
 
   def contact_gp?

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -94,7 +94,7 @@ private
   end
 
   def sanitised_session
-    session_with_indifferent_access.except(:_csrf_token, :current_path, :previous_path, :check_answers_seen)
+    session_with_indifferent_access.except(:session_id, :_csrf_token, :current_path, :previous_path, :check_answers_seen)
   end
 
   def contact_gp?

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -145,9 +145,6 @@
     },
     "reference_id": {
       "type": "string"
-    },
-    "session_id": {
-      "type": "string"
     }
   },
   "definitions": {

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -143,22 +143,7 @@
     "carry_supplies": {
       "$ref": "#/definitions/yes_no"
     },
-    "current_path": {
-      "type": "string"
-    },
-    "previous_path": {
-      "type": "string"
-    },
-    "check_answers_seen": {
-      "type": "boolean"
-    },
     "reference_id": {
-      "type": "string"
-    },
-    "_csrf_token": {
-      "type": "string"
-    },
-    "session_id": {
       "type": "string"
     }
   },

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -145,6 +145,9 @@
     },
     "reference_id": {
       "type": "string"
+    },
+    "session_id": {
+      "type": "string"
     }
   },
   "definitions": {

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -299,23 +299,20 @@ RSpec.describe SchemaHelper, type: :helper do
         expect(validate_against_form_response_schema(data).first).to include("check_answers_seen")
       end
 
-      it "allows the session_id to be stored" do
-        data = valid_data.merge(session_id: SecureRandom.uuid)
-        expect(validate_against_form_response_schema(data)).to be_empty
-      end
-
       it "returns errors for unnecessary session keys" do
         data = valid_data.merge(
           check_answers_seen: true,
           _csrf_token: "abc",
           current_path: "/foo",
           previous_path: "/foo",
+          session_id: SecureRandom.uuid,
         )
         expect(validate_against_form_response_schema(data).first).to include(
           "check_answers_seen",
           "_csrf_token",
           "current_path",
           "previous_path",
+          "session_id",
         )
       end
     end

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -294,34 +294,26 @@ RSpec.describe SchemaHelper, type: :helper do
         expect(validate_against_form_response_schema(data)).to be_empty
       end
 
-      it "allows check_answers_seen to be stored" do
-        data = valid_data.merge(check_answers_seen: true)
-        expect(validate_against_form_response_schema(data)).to be_empty
-      end
-
       it "returns a list of errors when check_answers_seen has an invalid value" do
         data = valid_data.merge(check_answers_seen: "Foo")
         expect(validate_against_form_response_schema(data).first).to include("check_answers_seen")
       end
 
-      it "allows a _csrf_token to be stored" do
-        data = valid_data.merge(_csrf_token: "abc")
-        expect(validate_against_form_response_schema(data)).to be_empty
-      end
-
-      it "allows the current_path to be stored" do
-        data = valid_data.merge(current_path: "/foo")
-        expect(validate_against_form_response_schema(data)).to be_empty
-      end
-
-      it "allows the previous_path to be stored" do
-        data = valid_data.merge(previous_path: "/foo")
-        expect(validate_against_form_response_schema(data)).to be_empty
-      end
-
-      it "allows the session_id to be stored" do
-        data = valid_data.merge(session_id: SecureRandom.uuid)
-        expect(validate_against_form_response_schema(data)).to be_empty
+      it "returns errors for unnecessary session keys" do
+        data = valid_data.merge(
+          check_answers_seen: true,
+          _csrf_token: "abc",
+          current_path: "/foo",
+          previous_path: "/foo",
+          session_id: SecureRandom.uuid,
+        )
+        expect(validate_against_form_response_schema(data).first).to include(
+          "check_answers_seen",
+          "_csrf_token",
+          "current_path",
+          "previous_path",
+          "session_id",
+        )
       end
     end
   end

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -299,20 +299,23 @@ RSpec.describe SchemaHelper, type: :helper do
         expect(validate_against_form_response_schema(data).first).to include("check_answers_seen")
       end
 
+      it "allows the session_id to be stored" do
+        data = valid_data.merge(session_id: SecureRandom.uuid)
+        expect(validate_against_form_response_schema(data)).to be_empty
+      end
+
       it "returns errors for unnecessary session keys" do
         data = valid_data.merge(
           check_answers_seen: true,
           _csrf_token: "abc",
           current_path: "/foo",
           previous_path: "/foo",
-          session_id: SecureRandom.uuid,
         )
         expect(validate_against_form_response_schema(data).first).to include(
           "check_answers_seen",
           "_csrf_token",
           "current_path",
           "previous_path",
-          "session_id",
         )
       end
     end

--- a/spec/support/form_response_helper.rb
+++ b/spec/support/form_response_helper.rb
@@ -32,7 +32,6 @@ module FormResponseHelper
       basic_care_needs: I18n.t("coronavirus_form.questions.basic_care_needs.options").map { |_, item| item[:label] }.sample,
       dietary_requirements: I18n.t("coronavirus_form.questions.dietary_requirements.options").map { |_, item| item[:label] }.sample,
       carry_supplies: I18n.t("coronavirus_form.questions.carry_supplies.options").map { |_, item| item[:label] }.sample,
-      check_answers_seen: true,
     }
   end
 end


### PR DESCRIPTION
What
----

We're submitting a few fields in `FormResponse` records that shouldn't exist there. These keys, such as `_csrf_token` are being sent through to the data team.

The changes here are to sanitise the session data and remove unnecessary keys when persisting the form response to the DB.

How to review
-------------

After completing the questions check that the response data in the DB does not contain any of 
```
check_answers_seen
_csrf_token
current_path
previous_path
session_id
```
Links
-----

https://trello.com/c/SsnvWiaA/463-remove-unnecessary-fields-from-formresponse

