### PR TITLE
Only show food related questions if someone has food needs

### DIFF
--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -27,6 +27,8 @@ class CoronavirusForm::BasicCareNeedsController < ApplicationController
 private
 
   def previous_path
-    carry_supplies_path
+    return carry_supplies_path if @form_responses[:essential_supplies] == I18n.t("coronavirus_form.questions.essential_supplies.options.option_no.label")
+
+    essential_supplies_path
   end
 end

--- a/app/controllers/coronavirus_form/basic_care_needs_controller.rb
+++ b/app/controllers/coronavirus_form/basic_care_needs_controller.rb
@@ -18,18 +18,15 @@ class CoronavirusForm::BasicCareNeedsController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session[:check_answers_seen]
-      session[:basic_care_needs] = @form_responses[:basic_care_needs]
-      redirect_to check_your_answers_url
     else
       session[:basic_care_needs] = @form_responses[:basic_care_needs]
-      redirect_to dietary_requirements_url
+      redirect_to check_your_answers_url
     end
   end
 
 private
 
   def previous_path
-    essential_supplies_path
+    carry_supplies_path
   end
 end

--- a/app/controllers/coronavirus_form/carry_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/carry_supplies_controller.rb
@@ -18,9 +18,12 @@ class CoronavirusForm::CarrySuppliesController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    else
+    elsif session[:check_answers_seen]
       session[:carry_supplies] = @form_responses[:carry_supplies]
       redirect_to check_your_answers_url
+    else
+      session[:carry_supplies] = @form_responses[:carry_supplies]
+      redirect_to basic_care_needs_url
     end
   end
 

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -18,7 +18,7 @@ class CoronavirusForm::DietaryRequirementsController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif session[:check_answers_seen]
+    elsif session[:check_answers_seen] && session[:carry_supplies].present?
       session[:dietary_requirements] = @form_responses[:dietary_requirements]
       redirect_to check_your_answers_url
     else

--- a/app/controllers/coronavirus_form/dietary_requirements_controller.rb
+++ b/app/controllers/coronavirus_form/dietary_requirements_controller.rb
@@ -30,6 +30,6 @@ class CoronavirusForm::DietaryRequirementsController < ApplicationController
 private
 
   def previous_path
-    basic_care_needs_path
+    essential_supplies_path
   end
 end

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -18,16 +18,27 @@ class CoronavirusForm::EssentialSuppliesController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
+    elsif @form_responses[:essential_supplies] == I18n.t("coronavirus_form.questions.essential_supplies.options.option_no.label")
+      update_session_store
+      redirect_to dietary_requirements_url
     elsif session[:check_answers_seen]
-      session[:essential_supplies] = @form_responses[:essential_supplies]
+      update_session_store
       redirect_to check_your_answers_url
     else
-      session[:essential_supplies] = @form_responses[:essential_supplies]
-      redirect_to dietary_requirements_url
+      update_session_store
+      redirect_to basic_care_needs_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:essential_supplies] = @form_responses[:essential_supplies]
+    if @form_responses[:essential_supplies] == I18n.t("coronavirus_form.questions.essential_supplies.options.option_yes.label")
+      session[:dietary_requirements] = nil
+      session[:carry_supplies] = nil
+    end
+  end
 
   def previous_path
     nhs_number_path

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -18,15 +18,9 @@ class CoronavirusForm::EssentialSuppliesController < ApplicationController
       respond_to do |format|
         format.html { render controller_path, status: :unprocessable_entity }
       end
-    elsif @form_responses[:essential_supplies] == I18n.t("coronavirus_form.questions.essential_supplies.options.option_no.label")
-      update_session_store
-      redirect_to dietary_requirements_url
-    elsif session[:check_answers_seen]
-      update_session_store
-      redirect_to check_your_answers_url
     else
       update_session_store
-      redirect_to basic_care_needs_url
+      redirect_to next_page_url
     end
   end
 
@@ -38,6 +32,18 @@ private
       session[:dietary_requirements] = nil
       session[:carry_supplies] = nil
     end
+  end
+
+  def next_page_url
+    return dietary_requirements_url if answer_next_question?
+    return check_your_answers_url if session[:check_answers_seen]
+
+    basic_care_needs_url
+  end
+
+  def answer_next_question?
+    @form_responses[:essential_supplies] == I18n.t("coronavirus_form.questions.essential_supplies.options.option_no.label") &&
+      (session[:dietary_requirements].blank? || session[:carry_supplies].blank?)
   end
 
   def previous_path

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -23,7 +23,7 @@ class CoronavirusForm::EssentialSuppliesController < ApplicationController
       redirect_to check_your_answers_url
     else
       session[:essential_supplies] = @form_responses[:essential_supplies]
-      redirect_to basic_care_needs_url
+      redirect_to dietary_requirements_url
     end
   end
 

--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -1,4 +1,12 @@
 module AnswersHelper
+  SKIPPABLE_QUESTIONS = %w[
+    carry_supplies
+    check_contact_details
+    dietary_requirements
+    medical_conditions
+    nhs_number
+  ].freeze
+
   def answer_items
     answers = questions.map do |question|
       answer = concat_answer(session[question], question)
@@ -17,7 +25,7 @@ module AnswersHelper
   end
 
   def skip_question?(question, answer)
-    question.in?(%w[check_contact_details medical_conditions nhs_number]) && answer.nil?
+    question.in?(SKIPPABLE_QUESTIONS) && answer.nil?
   end
 
   def concat_answer(answer, question)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -471,15 +471,6 @@ en:
           option_no:
             label: "No"
         custom_select_error: Select yes if you have a way of getting essential supplies delivered at the moment
-      basic_care_needs:
-        title: Are your basic care needs being met at the moment?
-        hint: For example, you have family, friends or neighbours you can talk to, and who can help you wash, bathe and keep your house clean if you need them to.
-        options:
-          option_yes:
-            label: "Yes"
-          option_no:
-            label: "No"
-        custom_select_error: Select yes if your basic care needs are being met at the moment
       dietary_requirements:
         title: Do you have any special dietary requirements?
         hint: |
@@ -501,3 +492,12 @@ en:
           option_no:
             label: "No"
         custom_select_error: Select yes if there’s someone in the house who’s able to carry a delivery of supplies inside
+      basic_care_needs:
+        title: Are your basic care needs being met at the moment?
+        hint: For example, you have family, friends or neighbours you can talk to, and who can help you wash, bathe and keep your house clean if you need them to.
+        options:
+          option_yes:
+            label: "Yes"
+          option_no:
+            label: "No"
+        custom_select_error: Select yes if your basic care needs are being met at the moment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,17 +59,17 @@ Rails.application.routes.draw do
     get "/essential-supplies", to: "essential_supplies#show"
     post "/essential-supplies", to: "essential_supplies#submit"
 
-    # Question 10.0: Are your basic care needs being met at the moment?
-    get "/basic-care-needs", to: "basic_care_needs#show"
-    post "/basic-care-needs", to: "basic_care_needs#submit"
-
-    # Question 11.0: Do you have any special dietary requirements?
+    # Question 10.0: Do you have any special dietary requirements?
     get "/dietary-requirements", to: "dietary_requirements#show"
     post "/dietary-requirements", to: "dietary_requirements#submit"
 
-    # Question 12.0: Is there someone in the house who's able to carry a delivery of supplies inside?
+    # Question 11.0: Is there someone in the house who's able to carry a delivery of supplies inside?
     get "/carry-supplies", to: "carry_supplies#show"
     post "/carry-supplies", to: "carry_supplies#submit"
+
+    # Question 12.0: Are your basic care needs being met at the moment?
+    get "/basic-care-needs", to: "basic_care_needs#show"
+    post "/basic-care-needs", to: "basic_care_needs#submit"
 
     # Check answers page: Are you ready to send your application?
     get "/check-your-answers", to: "check_answers#show"

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -138,10 +138,10 @@
       "$ref": "#/definitions/yes_no"
     },
     "dietary_requirements": {
-      "$ref": "#/definitions/yes_no"
+      "$ref": "#/definitions/yes_no_optional"
     },
     "carry_supplies": {
-      "$ref": "#/definitions/yes_no"
+      "$ref": "#/definitions/yes_no_optional"
     },
     "reference_id": {
       "type": "string"
@@ -151,6 +151,10 @@
     "yes_no": {
       "type": "string",
       "enum": ["Yes", "No"]
+    },
+    "yes_no_optional": {
+      "type": ["string", "null"],
+      "enum": ["Yes", "No", null]
     }
   }
 }

--- a/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/basic_care_needs_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CoronavirusForm::BasicCareNeedsController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { basic_care_needs: selected }
-      expect(response).to redirect_to(dietary_requirements_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do

--- a/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/carry_supplies_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CoronavirusForm::CarrySuppliesController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { carry_supplies: selected }
-      expect(response).to redirect_to(check_your_answers_path)
+      expect(response).to redirect_to(basic_care_needs_path)
     end
 
     it "validates a valid option is chosen" do

--- a/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/dietary_requirements_controller_spec.rb
@@ -46,8 +46,16 @@ RSpec.describe CoronavirusForm::DietaryRequirementsController, type: :controller
       expect(response).to render_template(current_template)
     end
 
-    it "redirects to check your answers if check your answers previously seen" do
+    it "redirects to to next question if check your answers previously seen and later food question not answered" do
       session[:check_answers_seen] = true
+      post :submit, params: { dietary_requirements: selected }
+
+      expect(response).to redirect_to(carry_supplies_path)
+    end
+
+    it "redirects to check your answers if check your answers previously seen and later food question answered" do
+      session[:check_answers_seen] = true
+      session[:carry_supplies] = "Yes"
       post :submit, params: { dietary_requirements: selected }
 
       expect(response).to redirect_to(check_your_answers_path)

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { essential_supplies: selected }
-      expect(response).to redirect_to(basic_care_needs_path)
+      expect(response).to redirect_to(dietary_requirements_path)
     end
 
     it "validates a valid option is chosen" do

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -35,9 +35,23 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
       expect(response).to render_template(current_template)
     end
 
-    it "redirects to next step for a permitted response" do
-      post :submit, params: { essential_supplies: selected }
+    it "redirects to next step for a yes response" do
+      post :submit, params: { essential_supplies: I18n.t("coronavirus_form.questions.essential_supplies.options.option_yes.label") }
+      expect(response).to redirect_to(basic_care_needs_path)
+    end
+
+    it "redirects to next step for a no response" do
+      post :submit, params: { essential_supplies: I18n.t("coronavirus_form.questions.essential_supplies.options.option_no.label") }
       expect(response).to redirect_to(dietary_requirements_path)
+    end
+
+    it "clears session values for later food questions for a yes response" do
+      session[:dietary_requirements] = "Yes"
+      session[:carry_supplies] = "Yes"
+      post :submit, params: { essential_supplies: I18n.t("coronavirus_form.questions.essential_supplies.options.option_yes.label") }
+
+      expect(session[:dietary_requirements]).to be_nil
+      expect(session[:carry_supplies]).to be_nil
     end
 
     it "validates a valid option is chosen" do

--- a/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/essential_supplies_controller_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
   let(:current_template) { "coronavirus_form/essential_supplies" }
   let(:session_key) { :essential_supplies }
 
+  before :each do
+    session.clear
+  end
+
   describe "GET show" do
     it "renders the form" do
       session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
@@ -60,9 +64,34 @@ RSpec.describe CoronavirusForm::EssentialSuppliesController, type: :controller d
       expect(response).to render_template(current_template)
     end
 
-    it "redirects to check your answers if check your answers previously seen" do
+    it "redirects to check your answers if check your answers previously seen, user answers no and user has already answered later food questions" do
+      session[:dietary_requirements] = "Yes"
+      session[:carry_supplies] = "Yes"
       session[:check_answers_seen] = true
-      post :submit, params: { essential_supplies: selected }
+      post :submit, params: { essential_supplies: I18n.t("coronavirus_form.questions.essential_supplies.options.option_no.label") }
+
+      expect(response).to redirect_to(check_your_answers_path)
+    end
+
+    it "redirects to next food question if check your answers previously seen, user answers no and user has not already answered later food questions" do
+      session[:check_answers_seen] = true
+      post :submit, params: { essential_supplies: I18n.t("coronavirus_form.questions.essential_supplies.options.option_no.label") }
+
+      expect(response).to redirect_to(dietary_requirements_path)
+    end
+
+    it "redirects to check your answers if check your answers previously seen, user answers yes and user has already answered later food questions" do
+      session[:dietary_requirements] = "Yes"
+      session[:carry_supplies] = "Yes"
+      session[:check_answers_seen] = true
+      post :submit, params: { essential_supplies: I18n.t("coronavirus_form.questions.essential_supplies.options.option_yes.label") }
+
+      expect(response).to redirect_to(check_your_answers_path)
+    end
+
+    it "redirects to check your answers if check your answers previously seen, user answers yes and user has not already answered later food questions" do
+      session[:check_answers_seen] = true
+      post :submit, params: { essential_supplies: I18n.t("coronavirus_form.questions.essential_supplies.options.option_yes.label") }
 
       expect(response).to redirect_to(check_your_answers_path)
     end

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -17,9 +17,9 @@ RSpec.feature "fill in the vulnerable people form" do
       and_has_checked_their_contact_details
       and_has_given_their_nhs_number
       and_is_not_getting_any_essential_supplies
-      and_their_basic_care_needs_are_not_being_met
       and_does_not_have_any_special_dietary_requirements
       where_there_is_no_one_available_to_carry_supplies
+      and_their_basic_care_needs_are_not_being_met
       and_has_accepted_the_terms_and_conditions
       then_they_can_be_supported
     end

--- a/spec/helpers/answers_helper_spec.rb
+++ b/spec/helpers/answers_helper_spec.rb
@@ -8,24 +8,20 @@ RSpec.describe AnswersHelper, type: :helper do
       end
     end
 
-    it "skips the check_contact_details question" do
-      expect(helper.answer_items.pluck(:field)).to_not include(
-        I18n.t("coronavirus_form.questions.check_contact_details.title"),
-      )
-    end
+    described_class::SKIPPABLE_QUESTIONS.each do |question|
+      context question do
+        it "includes the #{question} question if it has a value" do
+          session[question] = "1234567890"
+          expect(helper.answer_items.pluck(:field)).to include(
+            I18n.t("coronavirus_form.questions.#{question}.title"),
+          )
+        end
 
-    context "nhs_number" do
-      it "includes the nhs_number question if it has a value" do
-        session[:nhs_number] = "1234567890"
-        expect(helper.answer_items.pluck(:field)).to include(
-          I18n.t("coronavirus_form.questions.nhs_number.title"),
-        )
-      end
-
-      it "skips the nhs_number question if the value is nil" do
-        expect(helper.answer_items.pluck(:field)).to_not include(
-          I18n.t("coronavirus_form.questions.nhs_number.title"),
-        )
+        it "skips the #{question} question if the value is nil" do
+          expect(helper.answer_items.pluck(:field)).to_not include(
+            I18n.t("coronavirus_form.questions.#{question}.title"),
+          )
+        end
       end
     end
 
@@ -33,12 +29,6 @@ RSpec.describe AnswersHelper, type: :helper do
       it "includes the medical_conditions question if it has a value" do
         session[:medical_conditions] = I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes.label")
         expect(helper.answer_items.pluck(:field)).to include(
-          I18n.t("coronavirus_form.questions.medical_conditions.title"),
-        )
-      end
-
-      it "skips the medical_conditions question if the value is nil" do
-        expect(helper.answer_items.pluck(:field)).to_not include(
           I18n.t("coronavirus_form.questions.medical_conditions.title"),
         )
       end

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -274,6 +274,11 @@ RSpec.describe SchemaHelper, type: :helper do
         data = valid_data.merge(dietary_requirements: "Foo")
         expect(validate_against_form_response_schema(data).first).to include("dietary_requirements")
       end
+
+      it "does not return a list of errors when dietary_requirements has a nil value" do
+        data = valid_data.merge(dietary_requirements: nil)
+        expect(validate_against_form_response_schema(data)).to be_empty
+      end
     end
 
     describe "carry_supplies" do
@@ -285,6 +290,11 @@ RSpec.describe SchemaHelper, type: :helper do
       it "returns a list of errors when carry_supplies has an unexpected value" do
         data = valid_data.merge(carry_supplies: "Foo")
         expect(validate_against_form_response_schema(data).first).to include("carry_supplies")
+      end
+
+      it "does not return a list of errors when carry_supplies has a nil value" do
+        data = valid_data.merge(carry_supplies: nil)
+        expect(validate_against_form_response_schema(data)).to be_empty
       end
     end
 


### PR DESCRIPTION
What
----

- Changes the order of questions, so the "do you have any special dietary requirements" and "can you carry a box inside" questions come immediately after the "do you have a way of getting essential supplies delivered at the moment" question.
- Only shows the two later food questions if the user does not have a way of getting food.
- Updates the "previous" link target for subsequent food pages based on the user's answers.
- Removes the skippable questions from the "check your answers" page when the user has not answered them.
- Ensures a user is shown the skippable questions if they change their answer to say they do have problems getting food.

Not to be merged until approved by DWP call centre, and the data processing team.

How to review
-------------

- Review code changes.
- Run app locally, or use preview, to examine behaviour of `/essential-supplies` and subsequent questions when the different responses are given.  Also review the behaviour of changing your answer to the food questions.

Links
-----

Trello card: https://trello.com/c/IWPGeYTp