### PR TITLE
Mask user details in Sentry exception logs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,15 @@ Bundler.require(*Rails.groups)
 
 Raven.configure do |config|
   config.dsn = ENV["SENTRY_DSN"]
+  config.before_send = lambda { |event, _hint|
+    if event.extra.dig(:sidekiq, :job, :args, :arguments)
+      event.extra[:sidekiq][:job][:args][:arguments] = []
+    end
+    if event.extra.dig(:sidekiq, :jobstr)
+      event.extra[:sidekiq][:jobstr] = {}
+    end
+    event
+  }
 end
 
 module CoronavirusForm


### PR DESCRIPTION
## What

This changes configures Raven, the client for Sentry, so that PII data is taken out of the error report when sent to Sentry.

Specifically the entry in the hash `[:sidekiq][:job][:args][:arguments]` and `[:sidekiq][:jobstr]` which include name and telephone number .

## Why

We don't want to store or transfer any data unecessarily.
Sidekiq automatically logs some arguments we use for the job

What
----

Describe what you have changed and why.

How to review
-------------

Hard to test as we need to observe a sidekiq failure in Sentry and check the details have been scrubbed.

Links
-----

https://trello.com/c/rSX3xiS4/472-mask-user-details-in-sentry-exception-logs
