### PR TITLE
Run bundle before smoke tests

### DIFF
--- a/concourse/tasks/run-smoke-tests.yml
+++ b/concourse/tasks/run-smoke-tests.yml
@@ -12,6 +12,10 @@ params:
 inputs:
   - name: git-master
 run:
-  path: bundle
+  path: sh
   dir: git-master
-  args: ['exec', 'rspec', 'spec/features']
+  args:
+    - '-c'
+    - |
+      bundle
+      bundle exec rspec spec/features


### PR DESCRIPTION
Smoke tests can fail if they run with new code on an old
docker image without the pre-bundled depenendencies.

This ensures that the new gems have been installed before
we run the smoke tests.