### PR TITLE
Fix Schema Error

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -15,7 +15,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
     session[:reference_id] = submission_reference
 
-    validation_errors = validate_against_form_response_schema(session.to_h)
+    validation_errors = validate_against_form_response_schema(sanitised_session)
     if validation_errors.any?
       GovukError.notify(
         FormResponseInvalidError.new,

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -171,6 +171,8 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
       it "does not send a notification to Sentry if the data is valid" do
         expect(GovukError).to_not receive(:notify)
 
+        # Add one of the scrubbed items to the session to ensure it is sanitised and doesn't trigger notify
+        session[:session_id] = "dummy_id"
         session.merge!(valid_data)
         post :submit
       end


### PR DESCRIPTION
On the check answers page, a validation check was being performed on the non-sanitised version of the session. This failed validation due to having the keys `session_id`, `_csrf_token`, etc. still in the session and reported an error, but it did not present an error to the user.

This change uses the sanitised version of the session, with those keys removed and amends the spec.

How to review
-------------

Post deploy - observe no repeat of the error `FormResponseInvalidError`

Links
-----

https://trello.com/c/SsnvWiaA/463-remove-unnecessary-fields-from-formresponse
https://sentry.io/organizations/govuk/issues/1667664108/?project=5170680&query=is%3Aunresolved&statsPeriod=14d
