### PR TITLE
Guard against session contact_details being unset

### DIFF
--- a/app/controllers/coronavirus_form/check_contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/check_contact_details_controller.rb
@@ -37,6 +37,7 @@ class CoronavirusForm::CheckContactDetailsController < ApplicationController
 private
 
   def update_session_store
+    session[:contact_details] ||= {}
     session[:contact_details].merge!(@form_responses[:contact_details])
   end
 

--- a/spec/controllers/coronavirus_form/check_contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_contact_details_controller_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe CoronavirusForm::CheckContactDetailsController, type: :controller
       expect(session[:contact_details]).to eq existing_contact_details.merge(contact_details)
     end
 
+    context "session[:contact_details] is unset" do
+      before do
+        session[:contact_details] = nil
+      end
+
+      it "sets the new session variables successfully" do
+        post :submit, params: params
+        expect(session[:contact_details]).to eq contact_details
+      end
+    end
+
     it "redirects to next step for a permitted response" do
       post :submit, params: params
       expect(response).to redirect_to nhs_number_path


### PR DESCRIPTION
This is unexpected behaviour, but should prevent a user from seeing a 500 error if they don't have contact_details set.

Fixes https://sentry.io/organizations/govuk/issues/1703071294