### PR TITLE
Make dietary_requirements and carry_supplies optional

### DIFF
--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -9,9 +9,7 @@
     "support_address",
     "know_nhs_number",
     "essential_supplies",
-    "basic_care_needs",
-    "dietary_requirements",
-    "carry_supplies"
+    "basic_care_needs"
   ],
   "additionalProperties": false,
   "properties": {

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -265,11 +265,6 @@ RSpec.describe SchemaHelper, type: :helper do
     end
 
     describe "dietary_requirements" do
-      it "returns a list of errors when dietary_requirements is missing" do
-        data = valid_data.except(:dietary_requirements)
-        expect(validate_against_form_response_schema(data).first).to include("dietary_requirements")
-      end
-
       it "returns a list of errors when dietary_requirements has an unexpected value" do
         data = valid_data.merge(dietary_requirements: "Foo")
         expect(validate_against_form_response_schema(data).first).to include("dietary_requirements")
@@ -282,11 +277,6 @@ RSpec.describe SchemaHelper, type: :helper do
     end
 
     describe "carry_supplies" do
-      it "returns a list of errors when carry_supplies is missing" do
-        data = valid_data.except(:carry_supplies)
-        expect(validate_against_form_response_schema(data).first).to include("carry_supplies")
-      end
-
       it "returns a list of errors when carry_supplies has an unexpected value" do
         data = valid_data.merge(carry_supplies: "Foo")
         expect(validate_against_form_response_schema(data).first).to include("carry_supplies")


### PR DESCRIPTION
The questions that supply these fields are optional, so they
shouldn't be required in the schema.

Resolves https://sentry.io/organizations/govuk/issues/1667664108
https://trello.com/c/oxIwYzUD/534-make-two-schema-fields-optional
