### PR TITLE
Move the nhs number question

### DIFF
--- a/app/controllers/coronavirus_form/check_contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/check_contact_details_controller.rb
@@ -30,7 +30,7 @@ class CoronavirusForm::CheckContactDetailsController < ApplicationController
       redirect_to check_your_answers_url
     else
       update_session_store
-      redirect_to nhs_number_url
+      redirect_to essential_supplies_url
     end
   end
 

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -31,7 +31,7 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
       redirect_to check_your_answers_url
     else
       update_session_store
-      redirect_to nhs_number_url
+      redirect_to essential_supplies_url
     end
   end
 

--- a/app/controllers/coronavirus_form/essential_supplies_controller.rb
+++ b/app/controllers/coronavirus_form/essential_supplies_controller.rb
@@ -47,6 +47,6 @@ private
   end
 
   def previous_path
-    nhs_number_path
+    contact_details_path
   end
 end

--- a/app/controllers/coronavirus_form/medical_conditions_controller.rb
+++ b/app/controllers/coronavirus_form/medical_conditions_controller.rb
@@ -26,7 +26,7 @@ class CoronavirusForm::MedicalConditionsController < ApplicationController
       redirect_to check_your_answers_url
     else
       session[:medical_conditions] = @form_responses[:medical_conditions]
-      redirect_to name_url
+      redirect_to nhs_number_url
     end
   end
 

--- a/app/controllers/coronavirus_form/name_controller.rb
+++ b/app/controllers/coronavirus_form/name_controller.rb
@@ -43,8 +43,6 @@ private
   end
 
   def previous_path
-    return nhs_letter_path unless session[:medical_conditions]
-
-    medical_conditions_path
+    nhs_number_path
   end
 end

--- a/app/controllers/coronavirus_form/nhs_letter_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_letter_controller.rb
@@ -26,7 +26,7 @@ class CoronavirusForm::NhsLetterController < ApplicationController
       redirect_to check_your_answers_url
     elsif @form_responses[:nhs_letter] == I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
       set_session_values
-      redirect_to name_url
+      redirect_to nhs_number_url
     end
   end
 

--- a/app/controllers/coronavirus_form/nhs_number_controller.rb
+++ b/app/controllers/coronavirus_form/nhs_number_controller.rb
@@ -24,7 +24,7 @@ class CoronavirusForm::NhsNumberController < ApplicationController
       redirect_to check_your_answers_url
     else
       session[:nhs_number] = @form_responses[:nhs_number]
-      redirect_to essential_supplies_url
+      redirect_to name_url
     end
   end
 
@@ -47,6 +47,8 @@ private
   end
 
   def previous_path
-    contact_details_path
+    return nhs_letter_path unless session[:medical_conditions]
+
+    medical_conditions_path
   end
 end

--- a/spec/controllers/coronavirus_form/check_contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_contact_details_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe CoronavirusForm::CheckContactDetailsController, type: :controller
 
     it "redirects to next step for a permitted response" do
       post :submit, params: params
-      expect(response).to redirect_to nhs_number_path
+      expect(response).to redirect_to essential_supplies_path
     end
 
     it "does not move to next step with an invalid email address" do

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       }
 
       post :submit, params: params
-      expect(response).to redirect_to nhs_number_path
+      expect(response).to redirect_to essential_supplies_path
     end
 
     it "does not move to next step with an invalid phone number for calls" do
@@ -89,7 +89,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       it "permits the valid phone number #{number}" do
         post :submit, params: { "phone_number_calls": number }
         expect(response).to have_http_status(:found)
-        expect(response).to redirect_to nhs_number_path
+        expect(response).to redirect_to essential_supplies_path
       end
     end
 

--- a/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_conditions_controller_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe CoronavirusForm::MedicalConditionsController, type: :controller d
 
     it "redirects to next step for a yes (have medical condition) response" do
       post :submit, params: { medical_conditions: I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_medical.label") }
-      expect(response).to redirect_to(name_path)
+      expect(response).to redirect_to(nhs_number_path)
     end
 
     it "redirects to next step for a yes (GP or hospital told to shield) response" do
       post :submit, params: { medical_conditions: I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes_gp.label") }
-      expect(response).to redirect_to(name_path)
+      expect(response).to redirect_to(nhs_number_path)
     end
 
     it "redirects to ineligible page for a no response" do

--- a/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_letter_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe CoronavirusForm::NhsLetterController, type: :controller do
     it "redirects to what is your name question if user answers yes" do
       selected = I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
       post :submit, params: { nhs_letter: selected }
-      expect(response).to redirect_to(name_path)
+      expect(response).to redirect_to(nhs_number_path)
     end
 
     it "redirects to medical conditions question if user answers no" do

--- a/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/nhs_number_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe CoronavirusForm::NhsNumberController, type: :controller do
 
     it "redirects to next step for a valid NHS number" do
       post :submit, params: { nhs_number: valid_nhs_number }
-      expect(response).to redirect_to(essential_supplies_path)
+      expect(response).to redirect_to(name_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -10,12 +10,12 @@ RSpec.feature "fill in the vulnerable people form" do
       given_an_extremely_vulnerable_person_during_the_covid_19_pandemic
       that_lives_in_england
       and_has_recently_received_an_nhs_letter
+      and_has_given_their_nhs_number
       and_has_given_their_name
       and_has_given_their_date_of_birth
       and_has_given_their_address
       and_has_given_their_contact_details
       and_has_checked_their_contact_details
-      and_has_given_their_nhs_number
       and_is_not_getting_any_essential_supplies
       and_does_not_have_any_special_dietary_requirements
       where_there_is_no_one_available_to_carry_supplies
@@ -63,7 +63,7 @@ RSpec.feature "fill in the vulnerable people form" do
     and_has_not_recently_received_an_nhs_letter
     who_has_a_listed_medical_condition
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.name.title"))
+    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.nhs_number.title"))
   end
 
   scenario "ensure we can perform a healthcheck" do


### PR DESCRIPTION
This moves the NHS number question to immediately after the questions establishing whether a person is eligible. This is because the NHS number is something that people may not have immediately at hand so needs to be at the start of the flow.

