### PR TITLE
Add UPRN to schema

### DIFF
--- a/app/controllers/coronavirus_form/address_lookup_controller.rb
+++ b/app/controllers/coronavirus_form/address_lookup_controller.rb
@@ -18,6 +18,7 @@ class CoronavirusForm::AddressLookupController < ApplicationController
 
     address = JSON.parse(params[:address]).to_h
     session[:support_address] = helpers.convert_address(address)
+    session.delete(:postcode)
     redirect_to support_address_path
   rescue JSON::ParserError, AddressNotProvidedError
     render controller_path, status: :unprocessable_entity

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -97,6 +97,11 @@
         "postcode": {
           "type": "string",
           "pattern": "^[A-Za-z0-9 ]{4,}$"
+        },
+        "uprn": {
+          "type": ["string", "null"],
+          "maxLength": 12,
+          "pattern": "^[0-9]*$"
         }
       }
     },

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -159,6 +159,22 @@ RSpec.describe SchemaHelper, type: :helper do
 
         expect(validate_against_form_response_schema(data).first).to include("postcode")
       end
+
+      it "allows uprn to be unset" do
+        data = valid_data.tap do |valid_data|
+          valid_data[:support_address].delete(:uprn)
+        end
+
+        expect(validate_against_form_response_schema(data)).to be_empty
+      end
+
+      it "returns a list of errors when uprn has an invalid value" do
+        data = valid_data.tap do |valid_data|
+          valid_data[:support_address][:uprn] = "Foo"
+        end
+
+        expect(validate_against_form_response_schema(data).first).to include("uprn")
+      end
     end
 
     describe "contact_details" do

--- a/spec/support/form_response_helper.rb
+++ b/spec/support/form_response_helper.rb
@@ -20,6 +20,7 @@ module FormResponseHelper
         town_city: "City",
         county: "County",
         postcode: "E1 8QS",
+        uprn: "0123456789",
       },
       contact_details: {
         phone_number_calls: "0123456789",


### PR DESCRIPTION
Also removes postcode from top-level of session.

Fixes https://sentry.io/organizations/govuk/issues/1667664108

https://trello.com/c/Xug1GjUB/536-add-new-uprn-and-postcode-fields-to-schema
