### PR TITLE
Preserve query params when redirecting from /start

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get "/", to: redirect("https://www.gov.uk/coronavirus-extremely-vulnerable")
 
   scope module: "coronavirus_form" do
-    get "/start", to: redirect("/live-in-england")
+    get "/start", to: redirect(path: "/live-in-england")
 
     get "/privacy", to: "privacy#show"
     get "/accessibility-statement", to: "accessibility_statement#show"

--- a/spec/requests/start_spec.rb
+++ b/spec/requests/start_spec.rb
@@ -4,5 +4,11 @@ RSpec.describe "start" do
       get start_path
       expect(response).to redirect_to live_in_england_path
     end
+
+    it "preserves query parameters" do
+      get start_path, params: { foo: "123" }
+
+      expect(response).to redirect_to live_in_england_path(foo: "123")
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/4LpwmmCy
Follows on from: https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/356

Preview app 👉  https://coronavirus-preserve-st-0zmo2j.herokuapp.com/start?foo=123

# What's changed?

Pass any and all query string parameters from `/start` to the first
question.

For example: `/start?foo=123` now redirects to
`/live-in-england?foo=123` rather than `/live-in-england`

If no query params are passed in, `/start` redirects to
`/live-in-england` as before.

# Why?

We need to preserve the `_ga` parameter from GOV.UK to the service for
cross domain tracking to work.
The original 301 redirect broke this. I think it's because
analytics.js.erb isn't being called until a page in the form is loaded,
by which point we'd already lost the query params with the `_ga`
parameter.

# How to test locally

Run the app:

`foreman start`

Go to `localhost:5000/start?foo=123`

You should be redirected to `localhost:5000/live-in-england?foo=123`