### PR TITLE
Deactive HTML5 validation on email

### DIFF
--- a/app/views/coronavirus_form/check_contact_details.html.erb
+++ b/app/views/coronavirus_form/check_contact_details.html.erb
@@ -10,7 +10,7 @@
   <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
 <% end %>
 
-<%= form_tag(controller: "coronavirus_form/check_contact_details", action: "submit",
+<%= form_tag({ controller: "coronavirus_form/check_contact_details", action: "submit" },
   "data-module": "track-coronavirus-form-vulnerable-people-check_contact_details",
   "data-question-key": "check_contact_details",
   "novalidate": "true"


### PR DESCRIPTION
This makes the email input consistent with the other place we ask
users for input. We have server side validation for this, and I'm
told HTML5 validation isn't reliable.

https://trello.com/c/6wyg1U0O/549-remove-html5-validation-from-new-check-email-page
