### PR TITLE
check_contact_details: Handle `nil`  when finding email address

### DIFF
--- a/app/controllers/coronavirus_form/check_contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/check_contact_details_controller.rb
@@ -3,7 +3,7 @@
 class CoronavirusForm::CheckContactDetailsController < ApplicationController
   def show
     @form_responses = session.to_hash.with_indifferent_access
-    @email_suggestion = email_address_suggestion(@form_responses[:contact_details].dig(:email))
+    @email_suggestion = email_address_suggestion(@form_responses[:contact_details]&.dig(:email))
     super
   end
 
@@ -15,7 +15,7 @@ class CoronavirusForm::CheckContactDetailsController < ApplicationController
     }
 
     invalid_fields = [
-      @form_responses[:contact_details].dig(:email) ? validate_email_address("email", @form_responses.dig(:contact_details, :email)) : [],
+      @form_responses[:contact_details]&.dig(:email) ? validate_email_address("email", @form_responses&.dig(:contact_details, :email)) : [],
     ].flatten.compact
 
     if invalid_fields.any?


### PR DESCRIPTION
What
----

Handle `nil` contact details when trying to find email address

- We were seeing [Sentry errors](https://sentry.io/organizations/govuk/issues/1709557316/?project=5170680&referrer=slack):

```
undefined method `dig' for nil:NilClass
@email_suggestion = email_address_suggestion(@form_responses[:contact_details].dig(:email))
```

- We don't enforce that users must give us contact details (including email address) - because they might not have any of these details.



How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Observe that your local form doesn't get errors?

Links
-----

https://sentry.io/organizations/govuk/issues/1709557316/?project=5170680&referrer=slack
