### PR TITLE
Preserve user-provided name fields in name view

### DIFF
--- a/app/views/coronavirus_form/name.html.erb
+++ b/app/views/coronavirus_form/name.html.erb
@@ -10,7 +10,7 @@
   <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
 <% end %>
 
-<%= form_tag({},
+<%= form_tag({ controller: "coronavirus_form/name", action: "submit" },
   "data-module": "track-coronavirus-form-vulnerable-people-name",
   "data-question-key": "name",
   "novalidate": "true"
@@ -33,7 +33,7 @@
   id: "first_name",
   name: "first_name",
   error_message: error_items("first_name"),
-  value: @form_responses.dig(:name, "first_name"),
+  value: @form_responses.dig(:name, :first_name),
   autocomplete: "given-name",
 } %>
 
@@ -44,7 +44,7 @@
   id: "middle_name",
   name: "middle_name",
   error_message: error_items("middle_name"),
-  value: @form_responses.dig(:name, "middle_name"),
+  value: @form_responses.dig(:name, :middle_name),
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -54,7 +54,7 @@
   id: "last_name",
   name: "last_name",
   error_message: error_items("last_name"),
-  value: @form_responses.dig(:name, "last_name"),
+  value: @form_responses.dig(:name, :last_name),
   autocomplete: "family-name",
 } %>
 <%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>

--- a/spec/views/coronavirus_form/name.html.erb_spec.rb
+++ b/spec/views/coronavirus_form/name.html.erb_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "coronavirus_form/name" do
+  before do
+    allow(view).to receive(:previous_path).and_return("/")
+  end
+
+  context "when form fields have already been provided" do
+    it "shows the filled in fields" do
+      name = {
+        first_name: "Harry",
+        middle_name: "",
+        last_name: "Potter",
+      }
+      assign(:form_responses, name: name)
+
+      render
+      name.values.each do |txt|
+        expect(rendered).to have_selector("input[value='#{txt}']")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes a bug, where a user wouldn't be shown the names they had entered thanks to us using Strings instead of Symbols.

https://trello.com/c/AQs4RW9M/547-if-you-error-on-name-page-it-loses-any-data-you-entered-on-that-page