### PR TITLE
GA cross government domain tracking with test ID

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -6,6 +6,8 @@ var analyticsInit = function() {
   <% if Rails.application.config.analytics_tracking_id.present? %>
     var trackingId = "<%= Rails.application.config.analytics_tracking_id %>"
 
+    var crossDomainTrackingId = "<%= Rails.application.config.analytics_cross_domain_id %>"
+
     // Start analytics only if we have user consent
     var consentCookie = window.GOVUK.getConsentCookie();
     if (consentCookie && consentCookie["usage"]) {
@@ -14,10 +16,19 @@ var analyticsInit = function() {
                               m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga')
 
+      // /govuk-coronavirus-vulnerable-people-form Google Analytics
       ga('create', trackingId, 'auto')
       ga('set', 'allowAdFeatures', false);
       ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
+
+      // Cross Government Domain Google Analytics
+      ga('create', crossDomainTrackingId, 'auto', 'govuk_shared', {'allowLinker': true});
+      ga('govuk_shared.require', 'linker');
+      ga('govuk_shared.set', 'anonymizeIp', true);
+      ga('govuk_shared.set', 'allowAdFeatures', false);
+      ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
+      ga('govuk_shared.send', 'pageview');
     }
   <% end %>
 }

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -13,6 +13,7 @@ params:
   CF_PASSWORD: ((paas-password))
   CF_ORG: govuk_development
   GA_VIEW_ID: UA-43115970-1
+  GA_CROSS_DOMAIN_ID: UA-145652997-7
   SENTRY_DSN: https://((sentry-dsn))
   SECRET_KEY_BASE:
   CF_STARTUP_TIMEOUT:
@@ -61,6 +62,7 @@ run:
       cf set-env govuk-coronavirus-vulnerable-people-form AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
       cf set-env govuk-coronavirus-vulnerable-people-form SECRET_KEY_BASE "$SECRET_KEY_BASE"
       cf set-env govuk-coronavirus-vulnerable-people-form GA_VIEW_ID "$GA_VIEW_ID"
+      cf set-env govuk-coronavirus-vulnerable-people-form GA_CROSS_DOMAIN_ID "$GA_CROSS_DOMAIN_ID"
       cf set-env govuk-coronavirus-vulnerable-people-form METRICS_USERNAME "$METRICS_USERNAME"
       cf set-env govuk-coronavirus-vulnerable-people-form METRICS_PASSWORD "$METRICS_PASSWORD"
       cf set-env govuk-coronavirus-vulnerable-people-form GOVUK_NOTIFY_EMAIL_TEMPLATE_ID "$GOVUK_NOTIFY_EMAIL_TEMPLATE_ID"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,6 +56,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.analytics_tracking_id = "12345"
+  config.analytics_cross_domain_id = "54321"
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,6 +89,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   config.analytics_tracking_id = ENV["GA_VIEW_ID"]
+  config.analytics_cross_domain_id = ENV["GA_CROSS_DOMAIN_ID"]
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   config.analytics_tracking_id = "12345"
+  config.analytics_cross_domain_id = "54321"
 
   config.metrics_username = ENV["METRICS_USERNAME"] || "username"
 


### PR DESCRIPTION
What
----

Describe what you have changed and why.

- Adds Google Analytics cross domain tracking.
- Currently uses a test ID. This will need to be updated in a future PR once testing with a performance analyst is complete.

Why
----
We want to have as rich an understanding of cross-domain user journeys during coronavirus as possible.

How to review
-------------

Instructions for adding X-domain GA tracking are linked to the [Trello card](https://trello.com/c/q10D4CcH/499-add-cross-domain-tracking-to-business-volunteering-spike-the-complexity-1-day). This also gives information as to the process of testing with an analyst. 

- When sending analytics, we redact personally identifiable information. Although technically not personally identifiable, we are going to redact the query string params from the `/confirmation` path before switching to the live tracking ID, to prevent it becoming personally identifiable if in conjunction with the backend data.

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

This work is a spike. My hope is to merge this with the test ID and test with an analyst. Then everything will be in place for using a real ID when we want to start x-domain tracking. 

Links
-----
 [Trello card](https://trello.com/c/TRGembyC/558-add-cross-domain-tracking-to-the-sv-tool)

