### PR TITLE
Remove additional 'postcode' field from FormResponse

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -39,6 +39,8 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
     redirect_to confirmation_url(reference_number: submission_reference, contact_gp: @contact_gp)
   end
 
+  EXCLUDED_FIELDS = %i[session_id _csrf_token current_path previous_path check_answers_seen postcode].freeze
+
 private
 
   def smoke_tester?
@@ -94,7 +96,7 @@ private
   end
 
   def sanitised_session
-    session_with_indifferent_access.except(:session_id, :_csrf_token, :current_path, :previous_path, :check_answers_seen)
+    session_with_indifferent_access.except(*EXCLUDED_FIELDS)
   end
 
   def contact_gp?


### PR DESCRIPTION
This field is put into the session in postcode lookup controller but the data pipeline uses the support_address.postcode field.

This fixes a validation error: https://sentry.io/organizations/govuk/issues/1667664108
