### PR TITLE
Remove duplicate postcode field from session

### DIFF
--- a/app/controllers/coronavirus_form/address_lookup_controller.rb
+++ b/app/controllers/coronavirus_form/address_lookup_controller.rb
@@ -2,7 +2,7 @@
 
 class CoronavirusForm::AddressLookupController < ApplicationController
   def show
-    @addresses = helpers.postcode_lookup(session[:postcode])
+    @addresses = helpers.postcode_lookup(session.to_h.with_indifferent_access.dig(:support_address, :postcode))
     render controller_path, status: :ok
   rescue AddressAuthError => e
     session[:flash] = e.message
@@ -18,7 +18,6 @@ class CoronavirusForm::AddressLookupController < ApplicationController
 
     address = JSON.parse(params[:address]).to_h
     session[:support_address] = helpers.convert_address(address)
-    session.delete(:postcode)
     redirect_to support_address_path
   rescue JSON::ParserError, AddressNotProvidedError
     render controller_path, status: :unprocessable_entity

--- a/app/controllers/coronavirus_form/postcode_lookup_controller.rb
+++ b/app/controllers/coronavirus_form/postcode_lookup_controller.rb
@@ -23,7 +23,8 @@ class CoronavirusForm::PostcodeLookupController < ApplicationController
         flash.now[:validation] = errors
         render controller_path, status: :unprocessable_entity
       else
-        session[:postcode] = params[:postcode]
+        session[:support_address] ||= {}
+        session[:support_address]["postcode"] = strip_tags(params[:postcode]&.gsub(/[[:space:]]+/, "")).presence
         redirect_to address_lookup_path
       end
     end

--- a/app/views/coronavirus_form/address_lookup.html.erb
+++ b/app/views/coronavirus_form/address_lookup.html.erb
@@ -24,7 +24,7 @@
 } %>
 
 <p class="govuk-body">
-  <span class="govuk-!-font-weight-bold govuk-!-padding-right-3"><%= session[:postcode] %></span>
+  <span class="govuk-!-font-weight-bold govuk-!-padding-right-3"><%= session.dig(:support_address, :postcode) %></span>
   <%= link_to "Change", previous_path, class: "govuk-link" %>
 </p>
 

--- a/spec/controllers/coronavirus_form/address_lookup_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/address_lookup_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CoronavirusForm::AddressLookupController, type: :controller do
     context "valid postcode" do
       it "renders the postcode form" do
         VCR.use_cassette "/postcode/valid_postcode" do
-          session[:postcode] = address_data["valid_postcode"]["postcode"]
+          session[:support_address] = { postcode: address_data["valid_postcode"]["postcode"] }
           get :show
           expect(response).to render_template(current_template)
         end
@@ -42,7 +42,7 @@ RSpec.describe CoronavirusForm::AddressLookupController, type: :controller do
       it "redirects to postcode lookup page" do
         stub_request(:get, /#{AddressHelper::API_HOSTNAME}/).to_raise(Faraday::TimeoutError)
 
-        session[:postcode] = address_data["invalid_postcode"]["postcode"]
+        session[:support_address] = { postcode: address_data["invalid_postcode"]["postcode"] }
         get :show
 
         expect(response).to redirect_to(postcode_lookup_path)
@@ -52,7 +52,7 @@ RSpec.describe CoronavirusForm::AddressLookupController, type: :controller do
     context "invalid postcode" do
       it "renders an error message if the postcode is invalid" do
         VCR.use_cassette "/postcode/non_existant" do
-          session[:postcode] = address_data["invalid_postcode"]["postcode"]
+          session[:support_address] = { postcode: address_data["invalid_postcode"]["postcode"] }
 
           get :show
 
@@ -68,7 +68,7 @@ RSpec.describe CoronavirusForm::AddressLookupController, type: :controller do
       it "calls GovukError and redirects to support_address_path" do
         VCR.use_cassette "/postcode/invalid_api_key" do
           session[:live_in_england] = I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
-          session[:postcode] = address_data["valid_postcode"]["postcode"]
+          session[:support_address] = { postcode: address_data["valid_postcode"]["postcode"] }
 
           expect(GovukError).to receive(:notify)
           get :show


### PR DESCRIPTION
We store postcode in `session[:postcode]` for the postcode lookup,
but we can use `session[:support_address][:postcode]` instead, so
that we don't later have to remove this field from the session.