### PR TITLE
Stop the potential for non-string data

### DIFF
--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -105,8 +105,9 @@ module AddressHelper
         .with_indifferent_access
         .except(:uprn, :county, :town_city)
         .values
-        .map(&:to_s)
-        .map(&:upcase).join(" ")
+        .select { |value| value.instance_of?(String) }
+        .map(&:upcase)
+        .join(" ")
         .gsub(/[^0-9A-Z]+/, " ")
         .split(" ")
         .sort

--- a/spec/helpers/address_helper_spec.rb
+++ b/spec/helpers/address_helper_spec.rb
@@ -144,24 +144,21 @@ RSpec.describe AddressHelper, type: :helper do
       expect(helper.sanitize_address(address)).to eq array
     end
 
-    it "returns a valid array if part of the address is nil" do
+    it "returns an array of strings if the address contains non-string values" do
       address = {
-        one: "one two three 1234567890",
-        two: nil,
+        string: "one",
+        boolean: true,
+        null: nil,
+        integer: 100,
+        float: 1.34,
+        object: Object.new,
+        struct: Struct.new("Ignored"),
+        array: [],
+        hash: {},
+        symbol: :ignored,
         postcode: "AA1A 1AA",
       }
-      array = %w[1234567890 AA1A1AA ONE THREE TWO]
-
-      expect(helper.sanitize_address(address)).to eq array
-    end
-
-    it "returns a valid array if part of the address is a boolean" do
-      address = {
-        one: "one two three 1234567890",
-        two: false,
-        postcode: "AA1A 1AA",
-      }
-      array = %w[1234567890 AA1A1AA FALSE ONE THREE TWO]
+      array = %w[AA1A1AA ONE]
 
       expect(helper.sanitize_address(address)).to eq array
     end


### PR DESCRIPTION
During a recent incident it was noted that `True`, `False` and `nil` values were entering the `support_address` form data and causing a `NoMethodError` when passed into the `AddressHelper` module's methods.

This change removes all non-String data from the entered form data, prior to being saved.  Note that `instance_of?(String)` is used - instead of `is_a?` or `kind_of?` as it checks only the direct Object class and not any super-type(s) it might have.  So, this would also remove any data who's class is a sub-type of String.

Links
-----
[Incident Google Doc](https://docs.google.com/document/d/16qU8ZgSI7Y_IWN7F1nCkLWtVFvX_jw8VWwAiT9rs7EI/edit#heading=h.p99426yo0rbv)
[Incident investigation Trello card](https://trello.com/c/U8FR01EG/581-investigate-root-cause-of-incident)
