### PR TITLE
Fix flakey smoke test

### DIFF
--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -40,14 +40,14 @@ RSpec.feature "fill in the vulnerable people form" do
   scenario "visit an intermediate question without having previously visited the form" do
     visit essential_supplies_path
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.live_in_england.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.live_in_england.title"))
   end
 
   scenario "visitor not eligible as they live outside of England" do
     given_an_extremely_vulnerable_person_during_the_covid_19_pandemic
     who_does_not_live_in_england
 
-    expect(page.body).to have_content(I18n.t("not_eligible_england.title"))
+    expect(page).to have_content(I18n.t("not_eligible_england.title"))
   end
 
   scenario "visitor not eligible as they do not have a listed medical condition" do
@@ -56,7 +56,7 @@ RSpec.feature "fill in the vulnerable people form" do
     and_has_not_recently_received_an_nhs_letter
     who_does_not_have_a_listed_medical_condition
 
-    expect(page.body).to have_content(I18n.t("not_eligible_medical.title"))
+    expect(page).to have_content(I18n.t("not_eligible_medical.title"))
   end
 
   scenario "visitor has not received a letter, but has a medical condition" do
@@ -65,24 +65,24 @@ RSpec.feature "fill in the vulnerable people form" do
     and_has_not_recently_received_an_nhs_letter
     who_has_a_listed_medical_condition
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.nhs_number.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.nhs_number.title"))
   end
 
   scenario "ensure we can perform a healthcheck" do
     visit healthcheck_path
 
-    expect(page.body).to have_content("OK")
+    expect(page).to have_content("OK")
   end
 
   scenario "ensure the privacy notice page is visible" do
     visit privacy_path
 
-    expect(page.body).to have_content(I18n.t("privacy_page.title"))
+    expect(page).to have_content(I18n.t("privacy_page.title"))
   end
 
   scenario "ensure the accessibility statement page is visible" do
     visit accessibility_statement_path
 
-    expect(page.body).to have_content(I18n.t("accessibility_statement.title"))
+    expect(page).to have_content(I18n.t("accessibility_statement.title"))
   end
 end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -6,7 +6,7 @@ module FillInTheFormSteps
   end
 
   def that_lives_in_england
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.live_in_england.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.live_in_england.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.live_in_england.options.option_yes.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -14,7 +14,7 @@ module FillInTheFormSteps
   end
 
   def who_does_not_live_in_england
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.live_in_england.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.live_in_england.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.live_in_england.options.option_no.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -22,7 +22,7 @@ module FillInTheFormSteps
   end
 
   def and_has_recently_received_an_nhs_letter
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.nhs_letter.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.nhs_letter.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.nhs_letter.options.option_yes.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -30,7 +30,7 @@ module FillInTheFormSteps
   end
 
   def and_has_not_recently_received_an_nhs_letter
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.nhs_letter.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.nhs_letter.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.nhs_letter.options.option_no.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -38,7 +38,7 @@ module FillInTheFormSteps
   end
 
   def who_has_a_listed_medical_condition
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.medical_conditions.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.medical_conditions.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.medical_conditions.options.option_yes.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -46,7 +46,7 @@ module FillInTheFormSteps
   end
 
   def who_does_not_have_a_listed_medical_condition
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.medical_conditions.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.medical_conditions.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.medical_conditions.options.option_no.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -54,7 +54,7 @@ module FillInTheFormSteps
   end
 
   def and_has_given_their_name
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.name.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.name.title"))
     within find(".govuk-main-wrapper") do
       fill_in "first_name", with: "Test Please Ignore"
       fill_in "middle_name", with: "Test Please Ignore"
@@ -64,7 +64,7 @@ module FillInTheFormSteps
   end
 
   def and_has_given_their_date_of_birth
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.date_of_birth.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.date_of_birth.title"))
     within find(".govuk-main-wrapper") do
       fill_in "date_of_birth-day", with: "1"
       fill_in "date_of_birth-month", with: "1"
@@ -76,7 +76,7 @@ module FillInTheFormSteps
   def and_has_given_their_postcode
     VCR.turn_on!
     VCR.use_cassette "/postcode/valid_postcode" do
-      expect(page.body).to have_content(I18n.t("coronavirus_form.questions.postcode_lookup.title"))
+      expect(page).to have_content(I18n.t("coronavirus_form.questions.postcode_lookup.title"))
       within find(".govuk-main-wrapper") do
         fill_in "postcode", with: "SW1A2AA"
         click_on I18n.t("coronavirus_form.submit_and_next")
@@ -86,7 +86,7 @@ module FillInTheFormSteps
   end
 
   def and_has_selected_their_address
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.address_lookup.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.address_lookup.title"))
     within find(".govuk-main-wrapper") do
       address = "10, DOWNING STREET, LONDON, CITY OF WESTMINSTER, SW1A 2AA"
       select(address, from: :address)
@@ -95,7 +95,7 @@ module FillInTheFormSteps
   end
 
   def and_has_submited_their_address
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.support_address.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.support_address.title"))
     within find(".govuk-main-wrapper") do
       fill_in "building_and_street_line_1", with: "Test Please Ignore"
       fill_in "building_and_street_line_2", with: "Test Please Ignore"
@@ -107,7 +107,7 @@ module FillInTheFormSteps
   end
 
   def and_has_given_their_contact_details
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.contact_details.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.contact_details.title"))
     within find(".govuk-main-wrapper") do
       fill_in "phone_number_calls", with: Rails.application.config.test_telephone_number
       fill_in "phone_number_texts", with: Rails.application.config.test_telephone_number
@@ -117,14 +117,14 @@ module FillInTheFormSteps
   end
 
   def and_has_checked_their_contact_details
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.check_contact_details.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.check_contact_details.title"))
     within find(".govuk-main-wrapper") do
       click_on I18n.t("coronavirus_form.questions.check_contact_details.submit_and_next")
     end
   end
 
   def and_has_given_their_nhs_number
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.nhs_number.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.nhs_number.title"))
     within find(".govuk-main-wrapper") do
       fill_in "nhs_number", with: "1111111111"
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -132,7 +132,7 @@ module FillInTheFormSteps
   end
 
   def and_is_not_getting_any_essential_supplies
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.essential_supplies.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.essential_supplies.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.essential_supplies.options.option_no.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -140,7 +140,7 @@ module FillInTheFormSteps
   end
 
   def and_their_basic_care_needs_are_not_being_met
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.basic_care_needs.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.basic_care_needs.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.basic_care_needs.options.option_no.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -148,7 +148,7 @@ module FillInTheFormSteps
   end
 
   def and_does_not_have_any_special_dietary_requirements
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.dietary_requirements.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.dietary_requirements.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.dietary_requirements.options.option_no.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -156,7 +156,7 @@ module FillInTheFormSteps
   end
 
   def where_there_is_no_one_available_to_carry_supplies
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.carry_supplies.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.carry_supplies.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.carry_supplies.options.option_no.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -164,13 +164,13 @@ module FillInTheFormSteps
   end
 
   def and_has_accepted_the_terms_and_conditions
-    expect(page.body).to have_content(I18n.t("check_your_answers.title"))
+    expect(page).to have_content(I18n.t("check_your_answers.title"))
     within find(".govuk-main-wrapper") do
       click_on I18n.t("check_your_answers.submit")
     end
   end
 
   def then_they_can_be_supported
-    expect(page.body).to have_content(I18n.t("coronavirus_form.confirmation.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.confirmation.title"))
   end
 end


### PR DESCRIPTION

What
----
Following up from the change made in this commit
https://github.com/alphagov/govuk-coronavirus-find-support/pull/286/commits/276f12b1698015442cf39511bb65597475f54820
we are changing all instances of page.body to just be
page in order to avoid smoke test flakiness

Links
-----

[Trello](https://trello.com/c/LcjmW7vI/587-remove-uses-of-pagebody-from-all-feature-tests)

