### PR TITLE
Address incident recommendations

### DIFF
--- a/app/controllers/coronavirus_form/address_lookup_controller.rb
+++ b/app/controllers/coronavirus_form/address_lookup_controller.rb
@@ -16,7 +16,7 @@ class CoronavirusForm::AddressLookupController < ApplicationController
   def submit
     raise AddressNotProvidedError if params[:address].blank?
 
-    address = JSON.parse(params[:address]).to_h
+    address = helpers.remove_changes_to_ordnance_survey_api_response(params[:address])
     session[:support_address] = helpers.convert_address(address)
     redirect_to support_address_path
   rescue JSON::ParserError, AddressNotProvidedError

--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -56,12 +56,20 @@ private
 
   def given_address
     {
-      building_and_street_line_1: strip_tags(params[:building_and_street_line_1]&.strip).presence,
-      building_and_street_line_2: strip_tags(params[:building_and_street_line_2]&.strip).presence,
-      town_city: strip_tags(params[:town_city]&.strip).presence,
-      county: strip_tags(params[:county]&.strip).presence,
-      postcode: strip_tags(params[:postcode]&.gsub(/[[:space:]]+/, "")).presence,
+      building_and_street_line_1: strip_tags_from_address_field(params[:building_and_street_line_1]),
+      building_and_street_line_2: strip_tags_from_address_field(params[:building_and_street_line_2]),
+      town_city: strip_tags_from_address_field(params[:town_city]),
+      county: strip_tags_from_address_field(params[:county]),
+      postcode: strip_tags_from_postcode_field(params[:postcode]),
     }
+  end
+
+  def strip_tags_from_address_field(param)
+    param.nil? ? "" : strip_tags(param&.strip).presence
+  end
+
+  def strip_tags_from_postcode_field(postcode)
+    postcode.nil? ? "" : strip_tags(postcode&.gsub(/[[:space:]]+/, "")).presence
   end
 
   def validate_fields

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -123,4 +123,12 @@ module AddressHelper
 
     sanitized_edited_address & sanitized_ordnance_address == sanitized_ordnance_address
   end
+
+  def remove_changes_to_ordnance_survey_api_response(ordnance_address)
+    address = JSON.parse(ordnance_address).to_h
+
+    address.select do |key, value|
+      WANTED_VALUES.include?(key) && value.instance_of?(String)
+    end
+  end
 end

--- a/spec/controllers/coronavirus_form/support_address_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/support_address_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
     it "does not require address line 2" do
       post :submit, params: params.except("building_and_street_line_2")
 
-      expect(session[session_key]).to eq address.merge(building_and_street_line_2: nil)
+      expect(session[session_key]).to eq address.merge(building_and_street_line_2: "")
       expect(response).to redirect_to(next_page)
     end
 
@@ -81,8 +81,8 @@ RSpec.describe CoronavirusForm::SupportAddressController, type: :controller do
       post :submit, params: params.except("building_and_street_line_2", "county")
 
       expect(session[session_key]).to eq address.merge({
-        building_and_street_line_2: nil,
-        county: nil,
+        building_and_street_line_2: "",
+        county: "",
       })
 
       expect(response).to redirect_to(next_page)

--- a/spec/helpers/address_helper_spec.rb
+++ b/spec/helpers/address_helper_spec.rb
@@ -280,4 +280,77 @@ RSpec.describe AddressHelper, type: :helper do
       expect(helper.compare(ordnance_address, edited_address)).to be true
     end
   end
+
+  describe "#remove_changes_to_ordnance_survey_api_response" do
+    it "returns the same address if all fields exist in the Ordance Survery Places API response definition and all values are strings" do
+      selected_address = <<~ADDRESS.squish
+        {
+          "UPRN" : "123456789",
+          "SAO_TEXT" : "FLAT 1",
+          "PAO_TEXT" : "A BLOCK",
+          "STREET_DESCRIPTION" : "BEDROCK STREET",
+          "TOWN_NAME" : "BEDROCK",
+          "ADMINISTRATIVE_AREA" : "GREATER BEDROCK",
+          "POSTCODE_LOCATOR" : "BE1D 1RK"
+        }
+      ADDRESS
+
+      returned_address = {
+        "UPRN" => "123456789",
+        "SAO_TEXT" => "FLAT 1",
+        "PAO_TEXT" => "A BLOCK",
+        "STREET_DESCRIPTION" => "BEDROCK STREET",
+        "TOWN_NAME" => "BEDROCK",
+        "ADMINISTRATIVE_AREA" => "GREATER BEDROCK",
+        "POSTCODE_LOCATOR" => "BE1D 1RK",
+      }
+
+      expect(helper.remove_changes_to_ordnance_survey_api_response(selected_address)).to eq returned_address
+    end
+
+    it "removes all fields where the key does not exist in the Ordance Survery Places API response definition" do
+      changed_selected_address = <<~ADDRESS.squish
+        {
+          "UPRN" : "123456789",
+          "DANGER" : "FLAT 1",
+          "WILL" : "A BLOCK",
+          "ROBINSON" : "BEDROCK STREET",
+          "TOWN_NAME" : "BEDROCK",
+          "ADMINISTRATIVE_AREA" : "GREATER BEDROCK",
+          "POSTCODE_LOCATOR" : "BE1D 1RK"
+        }
+      ADDRESS
+
+      returned_address = {
+        "UPRN" => "123456789",
+        "TOWN_NAME" => "BEDROCK",
+        "ADMINISTRATIVE_AREA" => "GREATER BEDROCK",
+        "POSTCODE_LOCATOR" => "BE1D 1RK",
+      }
+
+      expect(helper.remove_changes_to_ordnance_survey_api_response(changed_selected_address)).to eq returned_address
+    end
+
+    it "removes all fields where the value is not a string" do
+      changed_selected_address = <<~ADDRESS.squish
+        {
+          "UPRN" : "123456789",
+          "SAO_TEXT" : null,
+          "PAO_TEXT" : false,
+          "STREET_DESCRIPTION" : 1.34,
+          "TOWN_NAME" : 1234,
+          "ADMINISTRATIVE_AREA" : "GREATER BEDROCK",
+          "POSTCODE_LOCATOR" : "BE1D 1RK"
+        }
+      ADDRESS
+
+      returned_address = {
+        "UPRN" => "123456789",
+        "ADMINISTRATIVE_AREA" => "GREATER BEDROCK",
+        "POSTCODE_LOCATOR" => "BE1D 1RK",
+      }
+
+      expect(helper.remove_changes_to_ordnance_survey_api_response(changed_selected_address)).to eq returned_address
+    end
+  end
 end


### PR DESCRIPTION
During a recent incident it was noted that `True`, `False` and `nil` values were entering the `support_address` form data and causing a `NoMethodError` when passed into the `AddressHelper` module's methods.

This change guards against `nil` fields which can be created by calling `presence` on `nil`, and removes any changes that may have been made to the selected address (the address that has been chosen from the address lookup results dropdown).  The `UPRN` field is additionally removed if it can no longer be trusted.

Links
-----

[Incident Google Doc](https://docs.google.com/document/d/16qU8ZgSI7Y_IWN7F1nCkLWtVFvX_jw8VWwAiT9rs7EI/edit#heading=h.p99426yo0rbv)
[Incident investigation Trello card](https://trello.com/c/U8FR01EG/581-investigate-root-cause-of-incident)
