### PR TITLE
Bug - postcode not showing

### DIFF
--- a/app/views/coronavirus_form/address_lookup.html.erb
+++ b/app/views/coronavirus_form/address_lookup.html.erb
@@ -24,7 +24,9 @@
 } %>
 
 <p class="govuk-body">
-  <span class="govuk-!-font-weight-bold govuk-!-padding-right-3"><%= session.dig(:support_address, :postcode) %></span>
+  <span class="govuk-!-font-weight-bold govuk-!-padding-right-3">
+    <%= session.to_h.with_indifferent_access.dig(:support_address, :postcode) %>
+  </span>
   <%= link_to "Change", previous_path, class: "govuk-link" %>
 </p>
 


### PR DESCRIPTION
Postcode is not visible to the left of the word 'Change' on the
address lookup page. It should be.

This change corrects the session hash lookup to be a string key
lookup and not symbol key.