### PR TITLE
Add missing type to input

### DIFF
--- a/app/views/coronavirus_form/support_address.html.erb
+++ b/app/views/coronavirus_form/support_address.html.erb
@@ -43,6 +43,7 @@
 <%= render "govuk_publishing_components/components/input", {
   id: "building_and_street_line_2",
   name: "building_and_street_line_2",
+  type: "text",
   error_message: error_items('building_and_street_line_2'),
   value: @form_responses.dig(:support_address, :building_and_street_line_2),
   autocomplete: "address-line2",


### PR DESCRIPTION
The input component for building_and_street_line_2 on the support
address page is missing.  While it is assumed that input tags will
default to type text, it is better to explicitly add it.

This change adds the missing type key to the component.