### PR TITLE
Bug - possible return of nil

### DIFF
--- a/app/controllers/coronavirus_form/support_address_controller.rb
+++ b/app/controllers/coronavirus_form/support_address_controller.rb
@@ -56,20 +56,12 @@ private
 
   def given_address
     {
-      building_and_street_line_1: strip_tags_from_address_field(params[:building_and_street_line_1]),
-      building_and_street_line_2: strip_tags_from_address_field(params[:building_and_street_line_2]),
-      town_city: strip_tags_from_address_field(params[:town_city]),
-      county: strip_tags_from_address_field(params[:county]),
-      postcode: strip_tags_from_postcode_field(params[:postcode]),
+      building_and_street_line_1: helpers.strip_tags_from_address_field(params[:building_and_street_line_1]),
+      building_and_street_line_2: helpers.strip_tags_from_address_field(params[:building_and_street_line_2]),
+      town_city: helpers.strip_tags_from_address_field(params[:town_city]),
+      county: helpers.strip_tags_from_address_field(params[:county]),
+      postcode: helpers.strip_tags_from_postcode_field(params[:postcode]),
     }
-  end
-
-  def strip_tags_from_address_field(param)
-    param.nil? ? "" : strip_tags(param&.strip).presence
-  end
-
-  def strip_tags_from_postcode_field(postcode)
-    postcode.nil? ? "" : strip_tags(postcode&.gsub(/[[:space:]]+/, "")).presence
   end
 
   def validate_fields

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -131,4 +131,12 @@ module AddressHelper
       WANTED_VALUES.include?(key) && value.instance_of?(String)
     end
   end
+
+  def strip_tags_from_address_field(address_field)
+    strip_tags(address_field&.strip).presence || ""
+  end
+
+  def strip_tags_from_postcode_field(postcode)
+    strip_tags_from_address_field(postcode).gsub(/[[:space:]]+/, "")
+  end
 end

--- a/spec/helpers/address_helper_spec.rb
+++ b/spec/helpers/address_helper_spec.rb
@@ -353,4 +353,36 @@ RSpec.describe AddressHelper, type: :helper do
       expect(helper.remove_changes_to_ordnance_survey_api_response(changed_selected_address)).to eq returned_address
     end
   end
+
+  describe "#strip_tags_from_address_field" do
+    it "strips HTML tags if there are any in the address field" do
+      expect(helper.strip_tags_from_address_field("<p>hello</p> <strong>world</strong>")).to eq "hello world"
+    end
+
+    it "returns the same value if there are no HTML tags in the address field" do
+      expect(helper.strip_tags_from_address_field("hello world")).to eq "hello world"
+    end
+
+    it "returns an empty string if there are only HTML tags in the address field but no content" do
+      expect(helper.strip_tags_from_address_field("<p></p>")).to eq ""
+    end
+
+    it "returns an empty string when given an empty string" do
+      expect(helper.strip_tags_from_address_field("")).to eq ""
+    end
+
+    it "returns an empty string when given nil" do
+      expect(helper.strip_tags_from_address_field(nil)).to eq ""
+    end
+  end
+
+  describe "#strip_tags_from_postcode_field" do
+    it "strips HTML tags if there are any in the postcode" do
+      expect(helper.strip_tags_from_postcode_field("<p>SW1A</p><strong>1AA</strong>")).to eq "SW1A1AA"
+    end
+
+    it "strips spaces if there are any in the postcode" do
+      expect(helper.strip_tags_from_postcode_field(" SW1A  1AA ")).to eq "SW1A1AA"
+    end
+  end
 end


### PR DESCRIPTION
During a recent incident it was noted that `True`, `False` and `nil` values were entering the `support_address` form data and causing a `NoMethodError` when passed into the `AddressHelper` module's methods.

Previous work had sought to resolve these issues.  However, it has been [noted](https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/406#discussion_r439323912) (thanks @leenagupte) that a `nil` return is still possible as calling presence after the strip_tags method on a string containing only tags will return nil.

This change fixes that issue and moves two methods into the AddressHelper, so that they can tested more easily, and refactors the moved methods to dry up the code.

Links
-----

[Incident Google Doc](https://docs.google.com/document/d/16qU8ZgSI7Y_IWN7F1nCkLWtVFvX_jw8VWwAiT9rs7EI/edit#)
[Incident Investigation Trello Card](https://trello.com/c/U8FR01EG/581-investigate-root-cause-of-incident)
