### PR TITLE
Use current and stable chrome version in Concourse pipeline

### DIFF
--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -7,14 +7,11 @@
 FROM ruby:2.6.6-buster
 
 RUN apt-get update --fix-missing && apt-get -y upgrade \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
+    && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
     && apt-get install -y --no-install-recommends \
-      google-chrome-unstable \
+      ./google-chrome-stable_current_amd64.deb \
       default-jre \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /src/*.deb
+    && rm ./google-chrome-stable_current_amd64.deb
 
 
 ENV CHROME_NO_SANDBOX=true


### PR DESCRIPTION
- We encountered a problem with the business-volunteers form pipeline, in which tests were failing due to capybara needing headless Chrome (https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/commit/27d5027cff0332a172628fa46465ab96fd40a55d).

- Updating our Concourse Dockerfile here as a precaution and to keep consistent with the business-volunteers form.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

Links
-----

[Trello](https://trello.com/c/gr48OyjA/628-fix-run-quality-checks-in-find-support-and-ev-pipelines)