### PR TITLE
Add feature test for minimal information

### DIFF
--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -131,7 +131,7 @@
       ]
     },
     "nhs_number": {
-      "type": ["string", "null"],
+      "type": "string",
       "pattern": "^[0-9]*$"
     },
     "essential_supplies": {

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "fill in the vulnerable people form" do
       and_has_given_their_date_of_birth
       and_has_given_their_postcode
       and_has_selected_their_address
-      and_has_submited_their_address
+      and_has_submitted_their_address
       and_has_given_their_contact_details
       and_has_checked_their_contact_details
       and_is_not_getting_any_essential_supplies
@@ -25,6 +25,25 @@ RSpec.feature "fill in the vulnerable people form" do
       and_has_accepted_the_terms_and_conditions
       then_they_can_be_supported
     end
+  end
+
+  scenario "fill in the form with minimal information" do
+    given_an_extremely_vulnerable_person_during_the_covid_19_pandemic
+    that_lives_in_england
+    and_has_recently_received_an_nhs_letter
+    and_has_given_their_nhs_number
+    and_has_given_the_minimal_name_information
+    and_has_given_their_date_of_birth
+    and_has_given_their_postcode
+    and_has_selected_their_address
+    and_has_submitted_the_miminum_address_information
+    and_has_given_no_contact_details
+    and_is_not_getting_any_essential_supplies
+    and_does_not_have_any_special_dietary_requirements
+    where_there_is_no_one_available_to_carry_supplies
+    and_their_basic_care_needs_are_not_being_met
+    and_has_accepted_the_terms_and_conditions
+    then_they_can_be_supported
   end
 
   describe "fill in the form" do

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -63,6 +63,15 @@ module FillInTheFormSteps
     end
   end
 
+  def and_has_given_the_minimal_name_information
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.name.title"))
+    within find(".govuk-main-wrapper") do
+      fill_in "first_name", with: "Test Please Ignore"
+      fill_in "last_name", with: "Test Please Ignore"
+      click_on I18n.t("coronavirus_form.submit_and_next")
+    end
+  end
+
   def and_has_given_their_date_of_birth
     expect(page).to have_content(I18n.t("coronavirus_form.questions.date_of_birth.title"))
     within find(".govuk-main-wrapper") do
@@ -94,7 +103,7 @@ module FillInTheFormSteps
     end
   end
 
-  def and_has_submited_their_address
+  def and_has_submitted_their_address
     expect(page).to have_content(I18n.t("coronavirus_form.questions.support_address.title"))
     within find(".govuk-main-wrapper") do
       fill_in "building_and_street_line_1", with: "Test Please Ignore"
@@ -106,12 +115,29 @@ module FillInTheFormSteps
     end
   end
 
+  def and_has_submitted_the_miminum_address_information
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.support_address.title"))
+    within find(".govuk-main-wrapper") do
+      fill_in "building_and_street_line_1", with: "Test Please Ignore"
+      fill_in "town_city", with: "Test Please Ignore"
+      fill_in "postcode", with: "ZZ99 9ZZ"
+      click_on I18n.t("coronavirus_form.submit_and_next")
+    end
+  end
+
   def and_has_given_their_contact_details
     expect(page).to have_content(I18n.t("coronavirus_form.questions.contact_details.title"))
     within find(".govuk-main-wrapper") do
       fill_in "phone_number_calls", with: Rails.application.config.test_telephone_number
       fill_in "phone_number_texts", with: Rails.application.config.test_telephone_number
       fill_in "email", with: Rails.application.config.courtesy_copy_email
+      click_on I18n.t("coronavirus_form.submit_and_next")
+    end
+  end
+
+  def and_has_given_no_contact_details
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.contact_details.title"))
+    within find(".govuk-main-wrapper") do
       click_on I18n.t("coronavirus_form.submit_and_next")
     end
   end


### PR DESCRIPTION
What
----

This feature test will check that a user can complete the form journey
providing the bare minimum information required.

I have also removed the abilty for nhs_number to be null as it is
now always required.

Why
----
We had an incident in which it was discovered that a lot of the errors were being caused by users not completing some fields. In all cases, these were fields that is user is allowed to leave blank, for example, `building_and_street_line_2` in the support address controller.

These values aren't just used in the controller where they're first stored, but across the app. So we need to check that these values can be `nil` at various places in the journey.

[Trello card](https://trello.com/c/dxNWr68o/615-add-a-feature-test-to-check-that-users-can-submit-forms-with-the-minimum-amount-of-information)


