### PR TITLE
Add an HTTP Content-Security-Policy

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,9 @@
     <%= yield :meta_tags %>
   </head>
   <body class="govuk-template__body">
-    <script>
+    <%= javascript_tag nonce: true do %>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end %>
     <%= render "govuk_publishing_components/components/cookie_banner", {
       title: t("cookies.banner.title"),
       text: t("cookies.banner.text"),
@@ -75,6 +75,6 @@
         ]
       }
     } %>
-    <%= javascript_include_tag "application" %>
+    <%= javascript_include_tag "application", nonce: true %>
   </body>
 </html>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy
@@ -6,25 +7,28 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/
 # Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src     :self, :https
+  policy.font_src        :self, :https, :data
+  policy.img_src         :self, :https, :data
+  policy.object_src      :none
+  policy.script_src      :self, :https, :data, "https://www.google-analytics.com"
+  policy.style_src       :self, :https
+  policy.media_src       :none
+  policy.child_src       :self
+  policy.form_action     :self
+  policy.frame_ancestors :self
+  policy.connect_src     :none
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  #   # Specify URI for violation reports
+  #   # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = ->
-# request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
 
 # Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives =
-# %w(script-src)
+Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:


### PR DESCRIPTION
What
----

As part of a security review of the service, it was noted that a Content-Security-Policy (CSP) is missing from the service.

A useful tool to assess an application's current header posture is Scott Helme's [`securityheaders.com`](https://securityheaders.com).  Using this on the production service reports an overall grade of `B`.  The highest being `A+`.

Three issues were reported:

  * A `Content-Security-Policy` is completely missing, despite Rails providing support for custom CSP's.
  * Likewise, a`Feature-Policy` is also missing.  This is a new(ish) header and currently un-supported in the present version of Rails used on service (v6.0.3).  However, support for this will be available in in Rails v6.1 - which expected by the end of July 2020. [This PR](https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/445) addresses the missing Feature-Policy.
  * Our `Set-Cookie` header has no `Cookie Prefix` on the cookie and that the cookie is not a `SameSite Cookie`.

Setting headers in a Rails application is done in two places (currently):

  1. In `config/application.rb` - for default headers
  2. In `config/initializers/content_security_policy.rb` - for CSP headers

Rails automatically includes _sensible_ defaults for the default headers.  These can be overridden if required in `config/application.rb`.  They are as follows...

```
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: strict-origin-when-cross-origin

# When `config.force_ssl = true` this header is also automatically set...
strict-transport-security: max-age=31536000; includeSubDomains
```

In addition, the `Cache-Control` header is already set in the service on a per-environment basis in the `config/environments/<environment>.rb` files, e.g.

```
Cache-Control: max-age=0, private, must-revalidate
```

As no issues are reported for any of the default headers, and that the existing default headers are restrictive in nature, it is felt that there is no need to change the default headers at this point.

This change adds a CSP to the service.

Most CSP headers are set to either `:self` (the origin from which the content is served should come from the same URL), or `:none` (effectively blocked or not allowed).  However, the `script_src` header is handled differently as it needs to handle Google Analytics and UJS.  Subsequently, the Google Analytics URL is explicitly specified and a `nonce` has been set.  Setting a `nonce` requires that the site's Javascript knows that a `nonce` is set.  This requires a parameter to be passed to `javascript_tag` and `javascript_include_tag` helpers.

How to review
-------------

You can (re)view the current HTTP headers via `cURL`...

```
# production

$ curl -L -A "Mozilla/5.0 (Windows NT 6.1; WOW64) \
        AppleWebKit/537.36 (KHTML, like Gecko) \
        Chrome/50.0.2661.102 Safari/537.36" \
        -s -D - https://coronavirus-vulnerable-people.service.gov.uk/live-in-england \
        -o /dev/null

# development

$ curl -L -A "Mozilla/5.0 (Windows NT 6.1; WOW64) \
        AppleWebKit/537.36 (KHTML, like Gecko) \
        Chrome/50.0.2661.102 Safari/537.36" \
        -s -D - http://localhost:5000/live-in-england \
        -o /dev/null
```

Other than viewing the headers, or running [`securityheaders.com`](https://securityheaders.com) - the best way to test if a header is set appropriately is to open `dev tools` on `console` and run the service.  Error's will be thrown if a header is too restrictive or set incorrectly. A general rule or best practice, is to start with the most restrictive header setting and adjust based on requirements and/or errors.

Links
-----

* [Trello card](https://trello.com/c/EPZNlbVz/598-do-a-security-review-of-the-extremely-vulnerable-people-service)
* [`securityheaders.com`](https://securityheaders.com)
* [Rails auto set default headers](https://edgeguides.rubyonrails.org/security.html#default-headers)
* [QWASP Secure Headers](https://owasp.org/www-project-secure-headers/)
* [Mozilla HTTP Headers Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers)