### PR TITLE
!!!DO NOT MERGE!!! Add a Feature-Policy

### DIFF
--- a/config/initializers/feature_policy.rb
+++ b/config/initializers/feature_policy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+if Rails.version >= "6.1" && Rails.application.config.respond_to?(:feature_policy)
+  Rails.application.config.feature_policy do |policy|
+    policy.geolocation   :none
+    policy.midi          :none
+    policy.notifications :none
+    policy.push          :none
+    policy.sync_xhr      :none
+    policy.microphone    :self
+    policy.camera        :none
+    policy.magnetometer  :none
+    policy.gyroscope     :none
+    policy.speaker       :self
+    # policy.vibrate       :self
+    policy.fullscreen    :self
+    policy.payment       :none
+  end
+end


### PR DESCRIPTION
<h1>!!! DO NOT MERGE THIS PR !!!</h1>

Wait until the Feature-Policy (or Permissions-Policy as it may become) has been finalised and Rails has support for it.

See [here for details](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy).


What
----

As part of a security review of the service, it was [noted](https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/444) that a Feature-Policy is missing from the service.

> Feature Policy allows web developers to selectively enable, disable, and modify the behaviour of certain APIs and web features in the browser. It's like CSP but instead of controlling security, it controls features! - [Google Developers Article](https://developers.google.com/web/updates/2018/06/feature-policy)

This change adds a Feature-Policy to the service.

The Feature-Policy headers are a new(ish) addition to the overall HTTP header set, and currently un-supported in the present version of Rails used on service (v6.0.3).  However, support for this will be available in in Rails v6.1 - which is expected to be released by the end of July 2020.  Therefore, in order not to create a blocked story or PR the Rails version is tested prior to injecting the policy.  This will automatically enable the Feature-Policy once the service has been upgraded to Rails v6.1 but silently ignored in the meantime.

Feature-Policy headers can be set to:

  * `*` (the feature is allowed by `self` and all `iframe`'s), 
  * `self` (the feature is only allowed from the same origin),
  * `none` (the feature is not allowed or blocked) or 
  * `origin(s)` (the feature is only allowed from the specified origins).  

As we are blocking `iframe`'s (see [this PR](https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/444)), and we currently do not use any external origin's, we only need to consider `self` (on or allowed) and `none` (off or disallowed) as viable options.  Following the principle of starting with the most restrictive header setting and relax or adjust based on requirements, all Feature-Policy headers have been set to `:none` - except where these features are needed for assistive technologies (i.e. microphone, speaker, fullscreen and vibrate).

Links
-----

* [Trello card](https://trello.com/c/EPZNlbVz/598-do-a-security-review-of-the-extremely-vulnerable-people-service)
* [`securityheaders.com`](https://securityheaders.com)
* [What is a HTTP Feature-Policy?](https://scotthelme.co.uk/a-new-security-header-feature-policy)
* [Google Developers Article](https://developers.google.com/web/updates/2018/06/feature-policy)
* [Mozilla Feature-Policy documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy)
* [Rails v6.1 support for Feature-Policy headers](https://github.com/rails/rails/blob/bf19b8774e20e98f7fdcd3ac82ee17f9adee22d8/railties/test/application/feature_policy_test.rb)