### PR TITLE
Update allowed hosts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,8 +6,7 @@ Rails.application.configure do
 
   config.hosts = [
     "coronavirus-vulnerable-people.service.gov.uk",
-    "d18j9d8kwes7fb.cloudfront.net",
-    "govuk-coronavirus-vulnerable-people-form-prod.cloudapps.digital",
+    "d1du93z9ntmjv.cloudfront.net",
     "govuk-coronavirus-vulnerable-people-form-stg.cloudapps.digital",
   ]
 


### PR DESCRIPTION
- We were pointing at the wrong cloudfront address in staging. A snowflake address was created when the app was initially built. We are pointing to the cloudfront distribution what we have created via terraform

- We unmapped the cloudapps.digital route from prod. This is because we do not want users to use that route, all users should go through cloudfront.

Co-authored-by: Richard Towers <richard.towers@digital.cabinet-office.gov.uk>

