### PR TITLE
Reduce number of PaaS instances

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -173,7 +173,7 @@ jobs:
         file: git-master/concourse/tasks/deploy-to-govuk-paas.yml
         params:
           CF_SPACE: production
-          INSTANCES: 20
+          INSTANCES: 2
           WORKER_INSTANCES: 1
           CF_STARTUP_TIMEOUT: 15 # minutes
           REQUIRE_BASIC_AUTH:


### PR DESCRIPTION
This will reduce the number of PaaS instances in production from 20 to 2. This is because the service has been shut down. 2 instances will be enough to keep the redirect working.

Trello - https://trello.com/c/vYHAxDKJ/706-reduce-number-of-paas-instances-for-ev-form
