### PR TITLE
Remove smoke test for prod

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -199,33 +199,3 @@ jobs:
               :kaboom:
               Deploy to production for the Shielded Vulnerable service has failed
               Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-
-  - name: smoke-test-prod
-    serial: true
-    plan:
-      - get: git-master
-        trigger: true
-        passed: [deploy-to-prod]
-      - get: tests-image
-        passed: [build-tests-image]
-      - task: smoke-test
-        file: git-master/concourse/tasks/smoke-test.yml
-        timeout: 5m
-        params:
-          URL: 'https://coronavirus-vulnerable-people.service.gov.uk/live-in-england'
-          MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes. If this fails, you should investigate immediately."
-      - task: run-smoke-tests
-        file: git-master/concourse/tasks/run-smoke-tests.yml
-        params:
-          TEST_URL: 'https://coronavirus-vulnerable-people.service.gov.uk'
-        on_failure:
-          put: govuk-coronavirus-services-tech-slack
-          params:
-            channel: '#govuk-corona-services-tech'
-            username: 'Concourse (Shielded Vulnerable Service)'
-            icon_emoji: ':concourse:'
-            silent: true
-            text: |
-              :kaboom:
-              Production smoke tests for the Shielded Vulnerable service have failed
-              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME


### PR DESCRIPTION
What
----

We need to remove the smoke tests from the Extremely Vulnerable People pipeline. This is part of the plan to shut down the service. 

We only want to remove the job from the pipeline, not any of the code from the tests, this is because we may need to bring the application back at short notice. 

----

[Trello card](https://trello.com/c/FSmtnrfn/705-remove-the-smoke-tests-from-the-ev-pipeline)


